### PR TITLE
fix: token_verify fallback + dns_search partial matching (#5, #6)

### DIFF
--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -76,8 +76,20 @@ export async function handleDiagnosticsTool(
       }
 
       case "cloudflare_token_verify": {
-        const result = await client.get("/user/tokens/verify");
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+          const result = await client.get("/user/tokens/verify");
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch {
+          // Account-level API tokens cannot self-verify via /user/tokens/verify.
+          // Fall back to a lightweight zones call to confirm the token works.
+          const zones = await client.get<{ result: unknown[] }>("/zones", { per_page: 1 });
+          const verified = {
+            status: "active",
+            message: "Token verified via fallback (account-level tokens cannot use /user/tokens/verify)",
+            zones_accessible: Array.isArray(zones) ? zones.length : 1,
+          };
+          return { content: [{ type: "text", text: JSON.stringify(verified, null, 2) }] };
+        }
       }
 
       case "cloudflare_zone_health": {

--- a/src/tools/dns.ts
+++ b/src/tools/dns.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { CloudflareClient } from "../client/cloudflare-client.js";
+import type { DnsRecord } from "../client/types.js";
 import { ZoneNameOrIdSchema, RecordIdSchema, DnsRecordTypeSchema, TtlSchema } from "../utils/validation.js";
 
 // ---------------------------------------------------------------------------
@@ -351,10 +352,16 @@ export async function handleDnsTool(
       case "cloudflare_dns_search": {
         const parsed = DnsSearchSchema.parse(args);
         const zoneId = await client.resolveZoneId(parsed.zone_id);
-        const params: Record<string, unknown> = { name: parsed.name };
+        // Fetch all records and filter client-side for partial name match,
+        // since the CF API name param requires exact FQDN match.
+        const params: Record<string, unknown> = { per_page: 5000 };
         if (parsed.type !== undefined) params["type"] = parsed.type;
-        const result = await client.get(`/zones/${zoneId}/dns_records`, params);
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        const allRecords = await client.get<DnsRecord[]>(`/zones/${zoneId}/dns_records`, params);
+        const searchTerm = parsed.name.toLowerCase();
+        const filtered = (Array.isArray(allRecords) ? allRecords : []).filter(
+          (r: DnsRecord) => r.name.toLowerCase().includes(searchTerm),
+        );
+        return { content: [{ type: "text", text: JSON.stringify(filtered, null, 2) }] };
       }
 
       case "cloudflare_dns_export": {


### PR DESCRIPTION
## Summary
- Cherry-pick of fix commit `4e7c76e` — originally merged into `feature/1-scaffold-mcp-cloudflare` via PR #7, but PR #2 merged before #7 so the fix missed `main`
- `cloudflare_token_verify`: try/catch fallback for account-level tokens that can't self-verify via `/user/tokens/verify`
- `cloudflare_dns_search`: client-side filtering for partial name match (CF API requires exact FQDN)

Closes #5, closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)