### PR TITLE
docs: clarify license — non-commercial use only under AGPL (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.14.2
+
+- Clarify license: internal/commercial use requires commercial license (#9)
+
 ## v2026.03.14.1
 
 - 42 tools across 7 domains: Zones (4), DNS (9), Diagnostics (4), Tunnels (6), WAF (5), Zero Trust (6), Security & DDoS (8) (#1)

--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -20,9 +20,8 @@ You likely need a commercial license if:
 
 ## When You Do NOT Need a Commercial License
 
-- **Personal or internal use** — using the software as-is within your organization
+- **Personal or non-commercial use** — using the software for personal projects or non-commercial purposes
 - **Open-source projects** — integrating with other AGPL-3.0 or compatible open-source projects
-- **Unmodified use** — running the unmodified MCP server to manage your own Cloudflare account
 
 ## Obtaining a Commercial License
 
@@ -35,10 +34,10 @@ Commercial licenses are priced based on scope and usage. Sponsoring the project 
 ## FAQ
 
 **Q: Can I use mcp-cloudflare for free in my company?**
-A: Yes, as long as you comply with the AGPL-3.0 license terms (including making source code available if you modify it or offer it as a network service).
+A: If your company uses mcp-cloudflare internally as part of commercial operations, you need either full AGPL-3.0 compliance (which means releasing your complete source code under AGPL-3.0) or a commercial license. Free use under AGPL-3.0 is intended for open-source and non-commercial purposes.
 
 **Q: Does the AGPL apply if I just run the MCP server internally?**
-A: Running the unmodified server internally for your own use does not trigger the AGPL network service clause. You do not need a commercial license for this use case.
+A: Running the server internally within a commercial organization still means you are subject to the AGPL-3.0 license terms. If your organization cannot comply with AGPL-3.0 (e.g., releasing source code of any modifications or derivative works), you need a commercial license.
 
 **Q: What if I build a product that includes mcp-cloudflare?**
 A: If your product is proprietary (closed-source), you need a commercial license. If your product is also AGPL-3.0 licensed, you can use it under the open-source license.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
 This project is dual-licensed:
 
-- **Open Source**: [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE) — free for open-source and internal use
+- **Open Source**: [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE) — free for open-source and non-commercial use
 - **Commercial**: Available for proprietary integrations — see [COMMERCIAL_LICENSE.md](COMMERCIAL_LICENSE.md)
 
 If you use mcp-cloudflare in a proprietary product or SaaS offering, a commercial license is required. Support development by [sponsoring us on GitHub](https://github.com/sponsors/itunified-io).


### PR DESCRIPTION
## Summary
- Change 'free for open-source and internal use' → 'free for open-source and non-commercial use'
- Update COMMERCIAL_LICENSE.md FAQ to clarify commercial organizations need a commercial license

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)