### PR TITLE
Add 17 Workers KV/Scripts/Secrets/Analytics tools

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -18,6 +18,8 @@ Claude Code skills compose multiple MCP tools into higher-level workflows. Skill
 | cloudflare-tunnel-management | Auto | — | Tunnel management — create, configure ingress, monitor connections |
 | cloudflare-waf-management | Auto | — | WAF management — custom rules, rulesets, IP access, Under Attack |
 | cloudflare-zero-trust | Auto | — | Zero Trust — access apps, policies, identity providers, gateway |
+| cloudflare-kv-manage | Auto | — | Workers KV — namespace and key-value CRUD operations |
+| cloudflare-worker-deploy | Auto | — | Workers — script deployment, routes, secrets, analytics |
 
 ---
 
@@ -163,3 +165,42 @@ Claude Code skills compose multiple MCP tools into higher-level workflows. Skill
 - `cloudflare_zt_gateway_status` — Gateway status
 
 **Triggers:** User asks to manage Zero Trust applications, policies, or identity providers.
+
+---
+
+### cloudflare-kv-manage
+
+**Type:** Auto-invocable
+**Description:** Manages Workers KV namespaces and key-value pairs. Covers creating namespaces, listing keys, reading and writing values, setting TTLs, and deleting keys and namespaces.
+
+**Tools used:**
+- `cloudflare_kv_namespace_list` — List all KV namespaces
+- `cloudflare_kv_namespace_create` — Create a new namespace
+- `cloudflare_kv_namespace_delete` — Delete a namespace (destructive)
+- `cloudflare_kv_list_keys` — List keys with optional prefix filter
+- `cloudflare_kv_read` — Read value by key
+- `cloudflare_kv_write` — Write key-value pair with optional TTL
+- `cloudflare_kv_delete` — Delete a key
+
+**Triggers:** User asks to manage KV namespaces, store/retrieve values, or work with Workers KV.
+
+---
+
+### cloudflare-worker-deploy
+
+**Type:** Auto-invocable
+**Description:** Deploys and manages Cloudflare Workers scripts. Covers listing workers, deploying scripts, configuring routes, managing secrets, and viewing analytics. Handles the full deployment lifecycle.
+
+**Tools used:**
+- `cloudflare_worker_list` — List all worker scripts
+- `cloudflare_worker_deploy` — Deploy a worker script (multipart upload)
+- `cloudflare_worker_delete` — Delete a worker script (destructive)
+- `cloudflare_worker_route_list` — List routes for a zone
+- `cloudflare_worker_route_create` — Create a route for a zone
+- `cloudflare_worker_secret_list` — List secret names
+- `cloudflare_worker_secret_set` — Set a secret (value never echoed)
+- `cloudflare_worker_secret_delete` — Delete a secret
+- `cloudflare_worker_analytics` — Time-series invocation metrics
+- `cloudflare_worker_usage` — Per-script aggregated usage
+
+**Triggers:** User asks to deploy workers, manage worker routes or secrets, or view worker analytics.

--- a/.claude/skills/cloudflare-kv-manage/SKILL.md
+++ b/.claude/skills/cloudflare-kv-manage/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: cloudflare-kv-manage
+description: Manage Cloudflare Workers KV namespaces and key-value pairs — create, list, read, write, delete
+---
+
+# Cloudflare KV Management
+
+Manage Workers KV namespaces and key-value pairs using Cloudflare API.
+
+## Prerequisites
+
+- `CLOUDFLARE_API_TOKEN` with Workers KV permissions
+- `CLOUDFLARE_ACCOUNT_ID` set (required for all KV operations)
+
+## Workflows
+
+### List namespaces
+1. Call `cloudflare_kv_namespace_list` to see all KV namespaces
+
+### Create a namespace
+1. Call `cloudflare_kv_namespace_create` with a descriptive title
+2. Note the returned namespace ID for subsequent operations
+
+### List keys in a namespace
+1. Call `cloudflare_kv_list_keys` with `namespace_id`
+2. Use `prefix` to filter keys by prefix
+3. Use `cursor` for pagination through large key sets
+
+### Read a value
+1. Call `cloudflare_kv_read` with `namespace_id` and `key_name`
+2. Returns the raw string value stored at the key
+
+### Write a value
+1. Call `cloudflare_kv_write` with `namespace_id`, `key_name`, and `value`
+2. Optionally set `expiration_ttl` (minimum 60 seconds) for auto-expiring keys
+
+### Delete a key
+1. Call `cloudflare_kv_delete` with `namespace_id` and `key_name`
+2. Confirm before deleting — operation is not reversible
+
+### Delete a namespace (DESTRUCTIVE)
+1. **WARNING:** This deletes the namespace and ALL keys within it
+2. List keys first to confirm the namespace contents
+3. Call `cloudflare_kv_namespace_delete` with `namespace_id`
+4. Always ask for user confirmation before executing
+
+## Tools Used
+
+- `cloudflare_kv_namespace_list` — List all KV namespaces
+- `cloudflare_kv_namespace_create` — Create a new namespace
+- `cloudflare_kv_namespace_delete` — Delete a namespace (destructive)
+- `cloudflare_kv_list_keys` — List keys with optional prefix filter
+- `cloudflare_kv_read` — Read value by key
+- `cloudflare_kv_write` — Write key-value pair with optional TTL
+- `cloudflare_kv_delete` — Delete a key
+
+## Rules
+
+- Always list namespaces first if the user hasn't specified one
+- Confirm before any delete operation (key or namespace)
+- Namespace deletion is destructive — list keys first to show what will be lost
+- KV keys are limited to 512 characters
+- Values are stored as strings — for structured data, consider JSON encoding

--- a/.claude/skills/cloudflare-worker-deploy/SKILL.md
+++ b/.claude/skills/cloudflare-worker-deploy/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: cloudflare-worker-deploy
+description: Deploy and manage Cloudflare Workers — upload scripts, configure routes, manage secrets, view analytics
+---
+
+# Cloudflare Worker Deployment & Management
+
+Deploy Workers scripts, configure routes, manage secrets, and monitor analytics.
+
+## Prerequisites
+
+- `CLOUDFLARE_API_TOKEN` with Workers permissions
+- `CLOUDFLARE_ACCOUNT_ID` set (required for script and secret operations)
+- Zone access for route management
+
+## Workflows
+
+### List existing workers
+1. Call `cloudflare_worker_list` to see all deployed scripts
+
+### Deploy a worker script
+1. Call `cloudflare_worker_deploy` with:
+   - `script_name` — unique name for the worker
+   - `script_content` — the JavaScript/TypeScript source code
+   - `content_type` — `application/javascript+module` (default, ES modules) or `application/javascript` (service worker)
+2. Verify deployment by checking the response
+3. Configure routes if needed (see below)
+
+### Configure routes for a worker
+1. Call `cloudflare_worker_route_list` with `zone_id` to see existing routes
+2. Call `cloudflare_worker_route_create` with:
+   - `zone_id` — the zone to add the route to
+   - `pattern` — URL pattern (e.g., `example.com/*`)
+   - `script` — the worker script name to handle matching requests
+
+### Manage worker secrets
+1. Call `cloudflare_worker_secret_list` with `script_name` to see current secrets (names only — values are never returned)
+2. Call `cloudflare_worker_secret_set` with `script_name`, `secret_name`, and `secret_value` to set a secret
+3. Call `cloudflare_worker_secret_delete` to remove a secret
+4. **Security:** Secret values are sent securely and never echoed in responses
+
+### View worker analytics
+1. Call `cloudflare_worker_analytics` for time-series metrics:
+   - Requests, errors, subrequests per time interval
+   - CPU time percentiles (P50, P99)
+   - Filter by `script_name` and `since` date
+2. Call `cloudflare_worker_usage` for aggregated per-script usage:
+   - Total requests, errors, subrequests per script
+   - Sorted by request count (highest first)
+
+### Delete a worker (DESTRUCTIVE)
+1. **WARNING:** This removes the worker script and stops serving all associated routes
+2. Check routes first with `cloudflare_worker_route_list`
+3. Call `cloudflare_worker_delete` with `script_name`
+4. Always ask for user confirmation before executing
+
+## Tools Used
+
+### Workers Scripts
+- `cloudflare_worker_list` — List all worker scripts
+- `cloudflare_worker_deploy` — Deploy a worker script (multipart upload)
+- `cloudflare_worker_delete` — Delete a worker script (destructive)
+- `cloudflare_worker_route_list` — List routes for a zone
+- `cloudflare_worker_route_create` — Create a route for a zone
+
+### Worker Secrets
+- `cloudflare_worker_secret_list` — List secret names (values never returned)
+- `cloudflare_worker_secret_set` — Set a secret (value never echoed)
+- `cloudflare_worker_secret_delete` — Delete a secret
+
+### Worker Analytics
+- `cloudflare_worker_analytics` — Time-series invocation metrics
+- `cloudflare_worker_usage` — Per-script aggregated usage
+
+## Deployment Workflow
+
+Recommended deployment sequence:
+1. `cloudflare_worker_deploy` — Upload the script
+2. `cloudflare_worker_secret_set` — Set required secrets (API keys, tokens)
+3. `cloudflare_worker_route_create` — Configure URL routing
+4. `cloudflare_worker_analytics` — Verify requests are being served
+
+## Rules
+
+- Always verify deployment succeeded by checking the response
+- Set secrets AFTER deploying (the script must exist first)
+- Confirm before destructive operations (delete script, delete secret)
+- Secret values are never logged or displayed — only names are shown
+- Route patterns use Cloudflare's pattern matching syntax (e.g., `*.example.com/api/*`)
+- ES modules format (`application/javascript+module`) is recommended for new workers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.15.1
+
+- **Add Workers KV tools** (7 tools) (#27)
+  - `cloudflare_kv_namespace_list`, `cloudflare_kv_namespace_create`, `cloudflare_kv_namespace_delete`
+  - `cloudflare_kv_list_keys`, `cloudflare_kv_read`, `cloudflare_kv_write`, `cloudflare_kv_delete`
+  - Client: add `putRaw()` method for raw body PUT requests
+- **Add Workers Scripts tools** (5 tools) (#28)
+  - `cloudflare_worker_list`, `cloudflare_worker_deploy`, `cloudflare_worker_delete`
+  - `cloudflare_worker_route_list`, `cloudflare_worker_route_create`
+  - Client: add `putForm()` method for multipart PUT requests
+- **Add Worker Secrets tools** (3 tools) (#29)
+  - `cloudflare_worker_secret_list`, `cloudflare_worker_secret_set`, `cloudflare_worker_secret_delete`
+  - Security: secret values are never echoed in tool output
+- **Add Worker Analytics tools** (2 tools) (#30)
+  - `cloudflare_worker_analytics`, `cloudflare_worker_usage`
+  - Account-scoped GraphQL queries for invocation metrics
+- **Add skills: cloudflare-kv-manage, cloudflare-worker-deploy** (#31)
+- New validation schemas: `NamespaceIdSchema`, `ScriptNameSchema`, `SecretNameSchema`, `KvKeySchema`
+- New types: `KvNamespace`, `KvKey`, `WorkerScript`, `WorkerRoute`, `WorkerSecret`, `WorkerAnalyticsRow`
+- Tool count: 42 → 59 (17 new tools across 4 modules)
+
 ## v2026.03.16.2
 
 - **Add pre-publish security scan** (#25)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Slim Cloudflare MCP Server for managing DNS, zones, tunnels, WAF, Zero Trust, an
 
 ## Features
 
-Tools across 6 domains:
+59 tools across 10 domains:
 
 - **DNS** — Record management (A, AAAA, CNAME, MX, TXT, SRV, CAA, NS), batch operations
 - **Zones** — Zone listing, settings, SSL/TLS configuration, cache management
@@ -33,6 +33,10 @@ Tools across 6 domains:
 - **WAF** — Ruleset management, custom firewall rules, rate limiting
 - **Zero Trust** — Access applications, policies, identity providers, Gateway status
 - **Security** — Security event analytics, IP access rules, DDoS configuration
+- **Workers KV** — Namespace management, key-value read/write/delete, key listing
+- **Workers** — Script deployment, route management
+- **Worker Secrets** — Secret management (names only, values never exposed)
+- **Worker Analytics** — Invocation metrics, CPU time, error rates via GraphQL
 
 ## Quick Start
 
@@ -80,6 +84,8 @@ Create an API Token at `dash.cloudflare.com/profile/api-tokens` with the followi
 - **WAF**: Zone > Firewall Services > Edit
 - **Zero Trust**: Account > Access: Apps and Policies > Edit
 - **Security events**: Zone > Analytics > Read
+- **Workers KV**: Account > Workers KV Storage > Edit
+- **Workers**: Account > Worker Scripts > Edit
 
 ## Multi-Zone Support
 
@@ -108,6 +114,8 @@ Claude Code skills compose MCP tools into higher-level workflows. See [`.claude/
 | cloudflare-tunnel-management | — | Tunnel management — create, configure ingress, monitor connections |
 | cloudflare-waf-management | — | WAF management — custom rules, rulesets, IP access, Under Attack |
 | cloudflare-zero-trust | — | Zero Trust — access apps, policies, identity providers, gateway |
+| cloudflare-kv-manage | — | Workers KV — namespace and key-value CRUD operations |
+| cloudflare-worker-deploy | — | Workers — script deployment, routes, secrets, analytics |
 
 ## Development
 

--- a/src/client/cloudflare-client.ts
+++ b/src/client/cloudflare-client.ts
@@ -127,6 +127,35 @@ export class CloudflareClient {
     }
   }
 
+  /**
+   * PUT with multipart/form-data (used for Workers script upload).
+   */
+  async putForm<T>(path: string, formData: FormData): Promise<T> {
+    try {
+      const response = await this.http.put<CloudflareResponse<T>>(path, formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      this.assertSuccess(response.data, `PUT ${path}`);
+      return response.data.result;
+    } catch (error: unknown) {
+      throw extractError(error, `PUT ${path}`);
+    }
+  }
+
+  /**
+   * PUT a raw text body (not JSON). Used for KV value writes.
+   */
+  async putRaw(path: string, body: string): Promise<void> {
+    try {
+      const response = await this.http.put<CloudflareResponse<unknown>>(path, body, {
+        headers: { "Content-Type": "text/plain" },
+      });
+      this.assertSuccess(response.data, `PUT ${path}`);
+    } catch (error: unknown) {
+      throw extractError(error, `PUT ${path}`);
+    }
+  }
+
   async graphql<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
     try {
       const response = await this.http.post<{ data: T; errors?: Array<{ message: string }> }>(

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -260,3 +260,62 @@ export interface IpAccessRule {
   created_on: string;
   modified_on: string;
 }
+
+// Workers KV types
+
+export interface KvNamespace {
+  id: string;
+  title: string;
+  supports_url_encoding: boolean;
+}
+
+export interface KvKey {
+  name: string;
+  expiration?: number;
+  metadata?: Record<string, unknown>;
+}
+
+// Workers Script types
+
+export interface WorkerScript {
+  id: string;
+  etag: string;
+  handlers: string[];
+  named_handlers?: Array<{ name: string; entrypoint: string }>;
+  modified_on: string;
+  created_on: string;
+  usage_model: string;
+  compatibility_date?: string;
+  compatibility_flags?: string[];
+}
+
+export interface WorkerRoute {
+  id: string;
+  pattern: string;
+  script: string;
+}
+
+// Worker Secret types
+
+export interface WorkerSecret {
+  name: string;
+  type: string;
+}
+
+// Worker Analytics types
+
+export interface WorkerAnalyticsRow {
+  dimensions: {
+    scriptName: string;
+    datetime?: string;
+  };
+  sum: {
+    requests: number;
+    errors: number;
+    subrequests: number;
+  };
+  quantiles: {
+    cpuTimeP50: number;
+    cpuTimeP99: number;
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,10 @@ import { tunnelsToolDefinitions, handleTunnelsTool } from './tools/tunnels.js';
 import { wafToolDefinitions, handleWafTool } from './tools/waf.js';
 import { zerotrustToolDefinitions, handleZerotrustTool } from './tools/zerotrust.js';
 import { securityToolDefinitions, handleSecurityTool } from './tools/security.js';
+import { kvToolDefinitions, handleKvTool } from './tools/kv.js';
+import { workersToolDefinitions, handleWorkersTool } from './tools/workers.js';
+import { workerSecretsToolDefinitions, handleWorkerSecretsTool } from './tools/worker-secrets.js';
+import { workerAnalyticsToolDefinitions, handleWorkerAnalyticsTool } from './tools/worker-analytics.js';
 
 const allToolDefinitions: Tool[] = ([
   ...zonesToolDefinitions,
@@ -22,6 +26,10 @@ const allToolDefinitions: Tool[] = ([
   ...wafToolDefinitions,
   ...zerotrustToolDefinitions,
   ...securityToolDefinitions,
+  ...kvToolDefinitions,
+  ...workersToolDefinitions,
+  ...workerSecretsToolDefinitions,
+  ...workerAnalyticsToolDefinitions,
 ] as unknown) as Tool[];
 
 const toolHandlers = new Map<
@@ -36,6 +44,10 @@ for (const def of tunnelsToolDefinitions) toolHandlers.set(def.name, handleTunne
 for (const def of wafToolDefinitions) toolHandlers.set(def.name, handleWafTool);
 for (const def of zerotrustToolDefinitions) toolHandlers.set(def.name, handleZerotrustTool);
 for (const def of securityToolDefinitions) toolHandlers.set(def.name, handleSecurityTool);
+for (const def of kvToolDefinitions) toolHandlers.set(def.name, handleKvTool);
+for (const def of workersToolDefinitions) toolHandlers.set(def.name, handleWorkersTool);
+for (const def of workerSecretsToolDefinitions) toolHandlers.set(def.name, handleWorkerSecretsTool);
+for (const def of workerAnalyticsToolDefinitions) toolHandlers.set(def.name, handleWorkerAnalyticsTool);
 
 const server = new Server(
   { name: 'mcp-cloudflare', version: '2026.3.13' },

--- a/src/tools/kv.ts
+++ b/src/tools/kv.ts
@@ -1,0 +1,259 @@
+import { z } from "zod";
+import type { CloudflareClient } from "../client/cloudflare-client.js";
+import { NamespaceIdSchema, KvKeySchema } from "../utils/validation.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const KvNamespaceListSchema = z.object({
+  page: z.number().int().min(1).optional(),
+  per_page: z.number().int().min(1).max(100).optional(),
+});
+
+const KvNamespaceCreateSchema = z.object({
+  title: z.string().min(1, "Namespace title is required"),
+});
+
+const KvNamespaceDeleteSchema = z.object({
+  namespace_id: NamespaceIdSchema,
+});
+
+const KvListKeysSchema = z.object({
+  namespace_id: NamespaceIdSchema,
+  prefix: z.string().optional(),
+  limit: z.number().int().min(1).max(1000).optional(),
+  cursor: z.string().optional(),
+});
+
+const KvReadSchema = z.object({
+  namespace_id: NamespaceIdSchema,
+  key_name: KvKeySchema,
+});
+
+const KvWriteSchema = z.object({
+  namespace_id: NamespaceIdSchema,
+  key_name: KvKeySchema,
+  value: z.string().min(0, "Value is required"),
+  expiration_ttl: z.number().int().min(60, "Expiration TTL must be at least 60 seconds").optional(),
+});
+
+const KvDeleteSchema = z.object({
+  namespace_id: NamespaceIdSchema,
+  key_name: KvKeySchema,
+});
+
+// ---------------------------------------------------------------------------
+// Account ID helper
+// ---------------------------------------------------------------------------
+
+function requireAccountId(client: CloudflareClient): string {
+  const accountId = client.getAccountId();
+  if (!accountId) {
+    throw new Error(
+      "CLOUDFLARE_ACCOUNT_ID environment variable is required for KV operations",
+    );
+  }
+  return accountId;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const kvToolDefinitions = [
+  {
+    name: "cloudflare_kv_namespace_list",
+    description: "List all Workers KV namespaces in the account.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        page: { type: "number", description: "Page number (default: 1)" },
+        per_page: { type: "number", description: "Results per page (1-100, default: 20)" },
+      },
+    },
+  },
+  {
+    name: "cloudflare_kv_namespace_create",
+    description: "Create a new Workers KV namespace in the account.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        title: { type: "string", description: "Title for the new KV namespace" },
+      },
+      required: ["title"],
+    },
+  },
+  {
+    name: "cloudflare_kv_namespace_delete",
+    description: "DESTRUCTIVE: Delete a Workers KV namespace by its ID. This removes all keys in the namespace.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        namespace_id: { type: "string", description: "KV namespace ID (32-character hex string)" },
+      },
+      required: ["namespace_id"],
+    },
+  },
+  {
+    name: "cloudflare_kv_list_keys",
+    description: "List keys stored in a Workers KV namespace. Supports prefix filtering and cursor-based pagination.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        namespace_id: { type: "string", description: "KV namespace ID (32-character hex string)" },
+        prefix: { type: "string", description: "Filter keys by prefix" },
+        limit: { type: "number", description: "Maximum number of keys to return (1-1000, default: 1000)" },
+        cursor: { type: "string", description: "Pagination cursor from a previous request" },
+      },
+      required: ["namespace_id"],
+    },
+  },
+  {
+    name: "cloudflare_kv_read",
+    description: "Read the value of a key from a Workers KV namespace. Returns the raw string value.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        namespace_id: { type: "string", description: "KV namespace ID (32-character hex string)" },
+        key_name: { type: "string", description: "Key name to read (max 512 characters)" },
+      },
+      required: ["namespace_id", "key_name"],
+    },
+  },
+  {
+    name: "cloudflare_kv_write",
+    description: "Write a value to a key in a Workers KV namespace. Optionally set a TTL for automatic expiration.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        namespace_id: { type: "string", description: "KV namespace ID (32-character hex string)" },
+        key_name: { type: "string", description: "Key name to write (max 512 characters)" },
+        value: { type: "string", description: "Value to store" },
+        expiration_ttl: { type: "number", description: "Time-to-live in seconds (minimum 60). Key is automatically deleted after this period." },
+      },
+      required: ["namespace_id", "key_name", "value"],
+    },
+  },
+  {
+    name: "cloudflare_kv_delete",
+    description: "Delete a key from a Workers KV namespace.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        namespace_id: { type: "string", description: "KV namespace ID (32-character hex string)" },
+        key_name: { type: "string", description: "Key name to delete (max 512 characters)" },
+      },
+      required: ["namespace_id", "key_name"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleKvTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: CloudflareClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "cloudflare_kv_namespace_list": {
+        const parsed = KvNamespaceListSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const params: Record<string, unknown> = {};
+        if (parsed.page !== undefined) params["page"] = parsed.page;
+        if (parsed.per_page !== undefined) params["per_page"] = parsed.per_page;
+        const result = await client.get(
+          `/accounts/${accountId}/storage/kv/namespaces`,
+          params,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_kv_namespace_create": {
+        const parsed = KvNamespaceCreateSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.post(
+          `/accounts/${accountId}/storage/kv/namespaces`,
+          { title: parsed.title },
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_kv_namespace_delete": {
+        const parsed = KvNamespaceDeleteSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.delete(
+          `/accounts/${accountId}/storage/kv/namespaces/${parsed.namespace_id}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_kv_list_keys": {
+        const parsed = KvListKeysSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const params: Record<string, unknown> = {};
+        if (parsed.prefix !== undefined) params["prefix"] = parsed.prefix;
+        if (parsed.limit !== undefined) params["limit"] = parsed.limit;
+        if (parsed.cursor !== undefined) params["cursor"] = parsed.cursor;
+        const result = await client.get(
+          `/accounts/${accountId}/storage/kv/namespaces/${parsed.namespace_id}/keys`,
+          params,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_kv_read": {
+        const parsed = KvReadSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.getRaw(
+          `/accounts/${accountId}/storage/kv/namespaces/${parsed.namespace_id}/values/${parsed.key_name}`,
+        );
+        return { content: [{ type: "text", text: result }] };
+      }
+
+      case "cloudflare_kv_write": {
+        const parsed = KvWriteSchema.parse(args);
+        const accountId = requireAccountId(client);
+        let path = `/accounts/${accountId}/storage/kv/namespaces/${parsed.namespace_id}/values/${parsed.key_name}`;
+        if (parsed.expiration_ttl !== undefined) {
+          path += `?expiration_ttl=${parsed.expiration_ttl}`;
+        }
+        await client.putRaw(path, parsed.value);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              success: true,
+              namespace_id: parsed.namespace_id,
+              key: parsed.key_name,
+              message: "Key written successfully.",
+            }, null, 2),
+          }],
+        };
+      }
+
+      case "cloudflare_kv_delete": {
+        const parsed = KvDeleteSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.delete(
+          `/accounts/${accountId}/storage/kv/namespaces/${parsed.namespace_id}/values/${parsed.key_name}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown KV tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/src/tools/worker-analytics.ts
+++ b/src/tools/worker-analytics.ts
@@ -1,0 +1,167 @@
+import { z } from "zod";
+import type { CloudflareClient } from "../client/cloudflare-client.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const WorkerAnalyticsSchema = z.object({
+  since: z.string().datetime({ offset: true }).optional(),
+  limit: z.number().int().min(1).max(10000).optional(),
+});
+
+const WorkerUsageSchema = z.object({
+  since: z.string().datetime({ offset: true }).optional(),
+  limit: z.number().int().min(1).max(10000).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// GraphQL query templates
+// ---------------------------------------------------------------------------
+
+const WORKER_ANALYTICS_QUERY = `
+query WorkerAnalytics($accountTag: string!, $since: Time!, $limit: Int!) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      workersInvocationsAdaptive(
+        filter: { datetime_gt: $since }
+        limit: $limit
+        orderBy: [datetime_DESC]
+      ) {
+        dimensions { scriptName datetime }
+        sum { requests errors subrequests }
+        quantiles { cpuTimeP50 cpuTimeP99 }
+      }
+    }
+  }
+}
+`.trim();
+
+const WORKER_USAGE_QUERY = `
+query WorkerUsage($accountTag: string!, $since: Time!, $limit: Int!) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      workersInvocationsAdaptive(
+        filter: { datetime_gt: $since }
+        limit: $limit
+        orderBy: [sum_requests_DESC]
+      ) {
+        dimensions { scriptName }
+        sum { requests errors subrequests }
+        quantiles { cpuTimeP50 cpuTimeP99 }
+      }
+    }
+  }
+}
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Account ID helper
+// ---------------------------------------------------------------------------
+
+function requireAccountId(client: CloudflareClient): string {
+  const accountId = client.getAccountId();
+  if (!accountId) {
+    throw new Error(
+      "CLOUDFLARE_ACCOUNT_ID environment variable is required for Worker Analytics operations",
+    );
+  }
+  return accountId;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const workerAnalyticsToolDefinitions = [
+  {
+    name: "cloudflare_worker_analytics",
+    description:
+      "Query Workers invocation analytics (time-series). Returns per-script metrics including requests, errors, subrequests, and CPU time percentiles ordered by time.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        since: {
+          type: "string",
+          description:
+            "ISO 8601 datetime to query from (default: 1 hour ago). E.g., '2026-03-15T00:00:00Z'",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of data points to return (default: 100, max: 10000)",
+        },
+      },
+    },
+  },
+  {
+    name: "cloudflare_worker_usage",
+    description:
+      "Query Workers usage summary (per-script aggregated). Returns scripts ranked by total request count, with error rates and CPU time percentiles.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        since: {
+          type: "string",
+          description:
+            "ISO 8601 datetime to query from (default: 24 hours ago). E.g., '2026-03-14T00:00:00Z'",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of scripts to return (default: 100, max: 10000)",
+        },
+      },
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleWorkerAnalyticsTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: CloudflareClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "cloudflare_worker_analytics": {
+        const parsed = WorkerAnalyticsSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const since =
+          parsed.since ?? new Date(Date.now() - 60 * 60 * 1000).toISOString();
+        const limit = parsed.limit ?? 100;
+        const result = await client.graphql<unknown>(WORKER_ANALYTICS_QUERY, {
+          accountTag: accountId,
+          since,
+          limit,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_worker_usage": {
+        const parsed = WorkerUsageSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const since =
+          parsed.since ?? new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+        const limit = parsed.limit ?? 100;
+        const result = await client.graphql<unknown>(WORKER_USAGE_QUERY, {
+          accountTag: accountId,
+          since,
+          limit,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown Worker Analytics tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/src/tools/worker-secrets.ts
+++ b/src/tools/worker-secrets.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+import type { CloudflareClient } from "../client/cloudflare-client.js";
+import { ScriptNameSchema, SecretNameSchema } from "../utils/validation.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const WorkerSecretListSchema = z.object({
+  script_name: ScriptNameSchema,
+});
+
+const WorkerSecretSetSchema = z.object({
+  script_name: ScriptNameSchema,
+  secret_name: SecretNameSchema,
+  secret_value: z.string().min(1, "Secret value is required"),
+});
+
+const WorkerSecretDeleteSchema = z.object({
+  script_name: ScriptNameSchema,
+  secret_name: SecretNameSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Account ID helper
+// ---------------------------------------------------------------------------
+
+function requireAccountId(client: CloudflareClient): string {
+  const accountId = client.getAccountId();
+  if (!accountId) {
+    throw new Error(
+      "CLOUDFLARE_ACCOUNT_ID environment variable is required for Worker Secrets operations",
+    );
+  }
+  return accountId;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const workerSecretsToolDefinitions = [
+  {
+    name: "cloudflare_worker_secret_list",
+    description: "List all secrets bound to a Workers script. Only secret names are returned, not values.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        script_name: { type: "string", description: "Worker script name (lowercase alphanumeric and hyphens)" },
+      },
+      required: ["script_name"],
+    },
+  },
+  {
+    name: "cloudflare_worker_secret_set",
+    description:
+      "Set a secret for a Workers script. Creates or updates the named secret. The secret value is NOT echoed in the response for security.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        script_name: { type: "string", description: "Worker script name (lowercase alphanumeric and hyphens)" },
+        secret_name: { type: "string", description: "Name of the secret (e.g., 'API_KEY', 'DB_PASSWORD')" },
+        secret_value: { type: "string", description: "Secret value to store" },
+      },
+      required: ["script_name", "secret_name", "secret_value"],
+    },
+  },
+  {
+    name: "cloudflare_worker_secret_delete",
+    description: "Delete a secret from a Workers script by name.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        script_name: { type: "string", description: "Worker script name (lowercase alphanumeric and hyphens)" },
+        secret_name: { type: "string", description: "Name of the secret to delete" },
+      },
+      required: ["script_name", "secret_name"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleWorkerSecretsTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: CloudflareClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "cloudflare_worker_secret_list": {
+        const parsed = WorkerSecretListSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.get(
+          `/accounts/${accountId}/workers/scripts/${parsed.script_name}/secrets`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_worker_secret_set": {
+        const parsed = WorkerSecretSetSchema.parse(args);
+        const accountId = requireAccountId(client);
+        await client.put(
+          `/accounts/${accountId}/workers/scripts/${parsed.script_name}/secrets`,
+          { name: parsed.secret_name, text: parsed.secret_value, type: "secret_text" },
+        );
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              success: true,
+              name: parsed.secret_name,
+              type: "secret_text",
+              message: "Secret set successfully. Value is not returned for security.",
+            }, null, 2),
+          }],
+        };
+      }
+
+      case "cloudflare_worker_secret_delete": {
+        const parsed = WorkerSecretDeleteSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.delete(
+          `/accounts/${accountId}/workers/scripts/${parsed.script_name}/secrets/${parsed.secret_name}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown Worker Secrets tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/src/tools/workers.ts
+++ b/src/tools/workers.ts
@@ -1,0 +1,203 @@
+import { z } from "zod";
+import type { CloudflareClient } from "../client/cloudflare-client.js";
+import { ScriptNameSchema, ZoneNameOrIdSchema } from "../utils/validation.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const WorkerListSchema = z.object({});
+
+const WorkerDeploySchema = z.object({
+  script_name: ScriptNameSchema,
+  script_content: z.string().min(1, "Script content is required"),
+  compatibility_date: z.string().min(1, "Compatibility date is required (e.g., 2026-03-15)"),
+  compatibility_flags: z.array(z.string()).optional(),
+  content_type: z.string().optional(),
+});
+
+const WorkerDeleteSchema = z.object({
+  script_name: ScriptNameSchema,
+});
+
+const WorkerRouteListSchema = z.object({
+  zone_id: ZoneNameOrIdSchema,
+});
+
+const WorkerRouteCreateSchema = z.object({
+  zone_id: ZoneNameOrIdSchema,
+  pattern: z.string().min(1, "Route pattern is required"),
+  script: ScriptNameSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Account ID helper
+// ---------------------------------------------------------------------------
+
+function requireAccountId(client: CloudflareClient): string {
+  const accountId = client.getAccountId();
+  if (!accountId) {
+    throw new Error(
+      "CLOUDFLARE_ACCOUNT_ID environment variable is required for Workers operations",
+    );
+  }
+  return accountId;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const workersToolDefinitions = [
+  {
+    name: "cloudflare_worker_list",
+    description: "List all Workers scripts deployed in the account.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "cloudflare_worker_deploy",
+    description:
+      "Deploy a Workers script. Creates or updates the named script with the provided source code.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        script_name: { type: "string", description: "Worker script name (lowercase alphanumeric and hyphens)" },
+        script_content: { type: "string", description: "JavaScript or TypeScript source code for the Worker" },
+        compatibility_date: { type: "string", description: "Compatibility date (e.g., '2026-03-15')" },
+        compatibility_flags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional compatibility flags (e.g., ['nodejs_compat'])",
+        },
+        content_type: {
+          type: "string",
+          description: "Content type of the script (default: 'application/javascript+module')",
+        },
+      },
+      required: ["script_name", "script_content", "compatibility_date"],
+    },
+  },
+  {
+    name: "cloudflare_worker_delete",
+    description: "DESTRUCTIVE: Delete a Workers script by name. This action cannot be undone.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        script_name: { type: "string", description: "Worker script name to delete" },
+      },
+      required: ["script_name"],
+    },
+  },
+  {
+    name: "cloudflare_worker_route_list",
+    description: "List all Workers routes for a zone. Routes map URL patterns to Worker scripts.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        zone_id: {
+          type: "string",
+          description: "Zone ID (32-char hex) or zone name (e.g., 'example.com')",
+        },
+      },
+      required: ["zone_id"],
+    },
+  },
+  {
+    name: "cloudflare_worker_route_create",
+    description: "Create a Workers route that maps a URL pattern to a Worker script for a zone.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        zone_id: {
+          type: "string",
+          description: "Zone ID (32-char hex) or zone name (e.g., 'example.com')",
+        },
+        pattern: { type: "string", description: "URL pattern to match (e.g., '*.example.com/api/*')" },
+        script: { type: "string", description: "Worker script name to route to" },
+      },
+      required: ["zone_id", "pattern", "script"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleWorkersTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: CloudflareClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "cloudflare_worker_list": {
+        WorkerListSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.get(
+          `/accounts/${accountId}/workers/scripts`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_worker_deploy": {
+        const parsed = WorkerDeploySchema.parse(args);
+        const accountId = requireAccountId(client);
+        const formData = new FormData();
+        const metadata = {
+          main_module: "worker.js",
+          compatibility_date: parsed.compatibility_date,
+          compatibility_flags: parsed.compatibility_flags,
+        };
+        formData.append("metadata", JSON.stringify(metadata));
+        formData.append("worker.js", parsed.script_content);
+        const result = await client.putForm(
+          `/accounts/${accountId}/workers/scripts/${parsed.script_name}`,
+          formData,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_worker_delete": {
+        const parsed = WorkerDeleteSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.delete(
+          `/accounts/${accountId}/workers/scripts/${parsed.script_name}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_worker_route_list": {
+        const parsed = WorkerRouteListSchema.parse(args);
+        const zoneId = await client.resolveZoneId(parsed.zone_id);
+        const result = await client.get(
+          `/zones/${zoneId}/workers/routes`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_worker_route_create": {
+        const parsed = WorkerRouteCreateSchema.parse(args);
+        const zoneId = await client.resolveZoneId(parsed.zone_id);
+        const result = await client.post(
+          `/zones/${zoneId}/workers/routes`,
+          { pattern: parsed.pattern, script: parsed.script },
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown Workers tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -85,3 +85,25 @@ export const IpAccessRuleTargetSchema = z.enum(["ip", "ip_range", "asn", "countr
 export const ZoneNameOrIdSchema = z
   .string()
   .min(1, "Zone name or ID is required");
+
+/** 32-character hex string used as Workers KV namespace IDs */
+export const NamespaceIdSchema = z
+  .string()
+  .regex(/^[0-9a-f]{32}$/i, "Invalid KV namespace ID (expected 32-character hex string)");
+
+/** Worker script name — lowercase alphanumeric with hyphens */
+export const ScriptNameSchema = z
+  .string()
+  .min(1, "Script name is required")
+  .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, "Invalid script name (lowercase alphanumeric and hyphens only)");
+
+/** Worker secret name */
+export const SecretNameSchema = z
+  .string()
+  .min(1, "Secret name is required");
+
+/** KV key name — max 512 bytes */
+export const KvKeySchema = z
+  .string()
+  .min(1, "KV key is required")
+  .max(512, "KV key must be 512 characters or less");

--- a/tests/tools/kv.test.ts
+++ b/tests/tools/kv.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi } from 'vitest';
+import { kvToolDefinitions, handleKvTool } from '../../src/tools/kv.js';
+import type { CloudflareClient } from '../../src/client/cloudflare-client.js';
+
+const ACCOUNT_ID = '00000000000000000000000000000001';
+const NAMESPACE_ID = '00000000000000000000000000000099';
+
+function mockClient(overrides: Partial<CloudflareClient> = {}): CloudflareClient {
+  return {
+    get: vi.fn().mockResolvedValue([]),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    resolveZoneId: vi.fn().mockResolvedValue('00000000000000000000000000000002'),
+    getRaw: vi.fn().mockResolvedValue(''),
+    getWithHeaders: vi.fn().mockResolvedValue({ result: [], headers: {} }),
+    postForm: vi.fn().mockResolvedValue({}),
+    putForm: vi.fn().mockResolvedValue({}),
+    putRaw: vi.fn().mockResolvedValue(undefined),
+    graphql: vi.fn().mockResolvedValue({}),
+    getAccountId: vi.fn().mockReturnValue(ACCOUNT_ID),
+    ...overrides,
+  } as unknown as CloudflareClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+describe('KV Tool Definitions', () => {
+  it('exports 7 tool definitions', () => {
+    expect(kvToolDefinitions).toHaveLength(7);
+  });
+
+  it('all tools have cloudflare_kv_ prefix', () => {
+    for (const tool of kvToolDefinitions) {
+      expect(tool.name).toMatch(/^cloudflare_kv_/);
+    }
+  });
+
+  it('all tools have non-empty descriptions', () => {
+    for (const tool of kvToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('all tools have inputSchema with type object', () => {
+    for (const tool of kvToolDefinitions) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleKvTool
+// ---------------------------------------------------------------------------
+
+describe('handleKvTool', () => {
+  describe('cloudflare_kv_namespace_list', () => {
+    it('lists namespaces with no filters', async () => {
+      const mockNs = [{ id: NAMESPACE_ID, title: 'MY_KV', supports_url_encoding: true }];
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockNs) });
+
+      const result = await handleKvTool('cloudflare_kv_namespace_list', {}, client);
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('MY_KV');
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/storage/kv/namespaces`,
+        {},
+      );
+    });
+
+    it('passes pagination params', async () => {
+      const client = mockClient({ get: vi.fn().mockResolvedValue([]) });
+
+      await handleKvTool('cloudflare_kv_namespace_list', { page: 2, per_page: 50 }, client);
+
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/storage/kv/namespaces`,
+        { page: 2, per_page: 50 },
+      );
+    });
+
+    it('returns error when account_id is missing', async () => {
+      const client = mockClient({ getAccountId: vi.fn().mockReturnValue(undefined) });
+
+      const result = await handleKvTool('cloudflare_kv_namespace_list', {}, client);
+
+      expect(result.content[0].text).toContain('CLOUDFLARE_ACCOUNT_ID');
+    });
+  });
+
+  describe('cloudflare_kv_namespace_create', () => {
+    it('creates a namespace', async () => {
+      const mockNs = { id: NAMESPACE_ID, title: 'NEW_KV' };
+      const client = mockClient({ post: vi.fn().mockResolvedValue(mockNs) });
+
+      const result = await handleKvTool(
+        'cloudflare_kv_namespace_create',
+        { title: 'NEW_KV' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('NEW_KV');
+      expect(client.post).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/storage/kv/namespaces`,
+        { title: 'NEW_KV' },
+      );
+    });
+
+    it('requires title parameter', async () => {
+      const client = mockClient();
+
+      const result = await handleKvTool('cloudflare_kv_namespace_create', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_kv_namespace_create');
+    });
+  });
+
+  describe('cloudflare_kv_namespace_delete', () => {
+    it('deletes a namespace by ID', async () => {
+      const client = mockClient({ delete: vi.fn().mockResolvedValue({}) });
+
+      await handleKvTool(
+        'cloudflare_kv_namespace_delete',
+        { namespace_id: NAMESPACE_ID },
+        client,
+      );
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}`,
+      );
+    });
+
+    it('rejects invalid namespace_id', async () => {
+      const client = mockClient();
+
+      const result = await handleKvTool(
+        'cloudflare_kv_namespace_delete',
+        { namespace_id: 'bad' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_kv_namespace_delete');
+    });
+  });
+
+  describe('cloudflare_kv_list_keys', () => {
+    it('lists keys in a namespace', async () => {
+      const mockKeys = [{ name: 'key1' }, { name: 'key2' }];
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockKeys) });
+
+      const result = await handleKvTool(
+        'cloudflare_kv_list_keys',
+        { namespace_id: NAMESPACE_ID },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('key1');
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/keys`,
+        {},
+      );
+    });
+
+    it('passes optional filters', async () => {
+      const client = mockClient({ get: vi.fn().mockResolvedValue([]) });
+
+      await handleKvTool(
+        'cloudflare_kv_list_keys',
+        { namespace_id: NAMESPACE_ID, prefix: 'config:', limit: 50, cursor: 'abc123' },
+        client,
+      );
+
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/keys`,
+        { prefix: 'config:', limit: 50, cursor: 'abc123' },
+      );
+    });
+  });
+
+  describe('cloudflare_kv_read', () => {
+    it('reads a key value', async () => {
+      const client = mockClient({ getRaw: vi.fn().mockResolvedValue('hello world') });
+
+      const result = await handleKvTool(
+        'cloudflare_kv_read',
+        { namespace_id: NAMESPACE_ID, key_name: 'my-key' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('hello world');
+      expect(client.getRaw).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/my-key`,
+      );
+    });
+
+    it('requires key_name parameter', async () => {
+      const client = mockClient();
+
+      const result = await handleKvTool(
+        'cloudflare_kv_read',
+        { namespace_id: NAMESPACE_ID },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_kv_read');
+    });
+  });
+
+  describe('cloudflare_kv_write', () => {
+    it('writes a key value', async () => {
+      const client = mockClient({ putRaw: vi.fn().mockResolvedValue(undefined) });
+
+      const result = await handleKvTool(
+        'cloudflare_kv_write',
+        { namespace_id: NAMESPACE_ID, key_name: 'my-key', value: 'hello' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('success');
+      expect(client.putRaw).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/my-key`,
+        'hello',
+      );
+    });
+
+    it('passes expiration_ttl as query param', async () => {
+      const client = mockClient({ putRaw: vi.fn().mockResolvedValue(undefined) });
+
+      await handleKvTool(
+        'cloudflare_kv_write',
+        { namespace_id: NAMESPACE_ID, key_name: 'ttl-key', value: 'data', expiration_ttl: 3600 },
+        client,
+      );
+
+      // putRaw is called with a path that includes the query param
+      const callPath = (client.putRaw as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(callPath).toContain('expiration_ttl=3600');
+    });
+
+    it('rejects expiration_ttl less than 60', async () => {
+      const client = mockClient();
+
+      const result = await handleKvTool(
+        'cloudflare_kv_write',
+        { namespace_id: NAMESPACE_ID, key_name: 'key', value: 'val', expiration_ttl: 10 },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_kv_write');
+    });
+
+    it('requires value parameter', async () => {
+      const client = mockClient();
+
+      const result = await handleKvTool(
+        'cloudflare_kv_write',
+        { namespace_id: NAMESPACE_ID, key_name: 'key' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_kv_write');
+    });
+  });
+
+  describe('cloudflare_kv_delete', () => {
+    it('deletes a key', async () => {
+      const client = mockClient({ delete: vi.fn().mockResolvedValue({}) });
+
+      await handleKvTool(
+        'cloudflare_kv_delete',
+        { namespace_id: NAMESPACE_ID, key_name: 'old-key' },
+        client,
+      );
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/old-key`,
+      );
+    });
+  });
+
+  describe('unknown tool', () => {
+    it('returns unknown tool message for unrecognized tool name', async () => {
+      const client = mockClient();
+
+      const result = await handleKvTool('cloudflare_kv_unknown', {}, client);
+
+      expect(result.content[0].text).toContain('Unknown KV tool');
+    });
+  });
+
+  describe('API error handling', () => {
+    it('returns error message when API call fails', async () => {
+      const client = mockClient({
+        get: vi.fn().mockRejectedValue(new Error('API request failed')),
+      });
+
+      const result = await handleKvTool('cloudflare_kv_namespace_list', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_kv_namespace_list');
+      expect(result.content[0].text).toContain('API request failed');
+    });
+  });
+});

--- a/tests/tools/worker-analytics.test.ts
+++ b/tests/tools/worker-analytics.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest';
+import { workerAnalyticsToolDefinitions, handleWorkerAnalyticsTool } from '../../src/tools/worker-analytics.js';
+import type { CloudflareClient } from '../../src/client/cloudflare-client.js';
+
+const ACCOUNT_ID = '00000000000000000000000000000001';
+
+function mockClient(overrides: Partial<CloudflareClient> = {}): CloudflareClient {
+  return {
+    get: vi.fn().mockResolvedValue([]),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    resolveZoneId: vi.fn().mockResolvedValue('00000000000000000000000000000002'),
+    getRaw: vi.fn().mockResolvedValue(''),
+    getWithHeaders: vi.fn().mockResolvedValue({ result: [], headers: {} }),
+    postForm: vi.fn().mockResolvedValue({}),
+    putForm: vi.fn().mockResolvedValue({}),
+    putRaw: vi.fn().mockResolvedValue(undefined),
+    graphql: vi.fn().mockResolvedValue({
+      viewer: {
+        accounts: [{
+          workersInvocationsAdaptive: [
+            {
+              dimensions: { scriptName: 'my-worker', datetime: '2026-03-15T00:00:00Z' },
+              sum: { requests: 100, errors: 2, subrequests: 10 },
+              quantiles: { cpuTimeP50: 1.5, cpuTimeP99: 8.2 },
+            },
+          ],
+        }],
+      },
+    }),
+    getAccountId: vi.fn().mockReturnValue(ACCOUNT_ID),
+    ...overrides,
+  } as unknown as CloudflareClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+describe('Worker Analytics Tool Definitions', () => {
+  it('exports 2 tool definitions', () => {
+    expect(workerAnalyticsToolDefinitions).toHaveLength(2);
+  });
+
+  it('all tools have cloudflare_worker_ prefix', () => {
+    for (const tool of workerAnalyticsToolDefinitions) {
+      expect(tool.name).toMatch(/^cloudflare_worker_/);
+    }
+  });
+
+  it('all tools have non-empty descriptions', () => {
+    for (const tool of workerAnalyticsToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('all tools have inputSchema with type object', () => {
+    for (const tool of workerAnalyticsToolDefinitions) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleWorkerAnalyticsTool
+// ---------------------------------------------------------------------------
+
+describe('handleWorkerAnalyticsTool', () => {
+  describe('cloudflare_worker_analytics', () => {
+    it('queries worker analytics via GraphQL', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkerAnalyticsTool('cloudflare_worker_analytics', {}, client);
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('my-worker');
+      expect(client.graphql).toHaveBeenCalledWith(
+        expect.stringContaining('workersInvocationsAdaptive'),
+        expect.objectContaining({
+          accountTag: ACCOUNT_ID,
+          since: expect.any(String),
+          limit: 100,
+        }),
+      );
+    });
+
+    it('passes custom since and limit', async () => {
+      const client = mockClient();
+
+      await handleWorkerAnalyticsTool(
+        'cloudflare_worker_analytics',
+        { since: '2026-03-14T00:00:00Z', limit: 50 },
+        client,
+      );
+
+      expect(client.graphql).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          since: '2026-03-14T00:00:00Z',
+          limit: 50,
+        }),
+      );
+    });
+
+    it('returns error when account_id is missing', async () => {
+      const client = mockClient({ getAccountId: vi.fn().mockReturnValue(undefined) });
+
+      const result = await handleWorkerAnalyticsTool('cloudflare_worker_analytics', {}, client);
+
+      expect(result.content[0].text).toContain('CLOUDFLARE_ACCOUNT_ID');
+    });
+  });
+
+  describe('cloudflare_worker_usage', () => {
+    it('queries worker usage via GraphQL', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkerAnalyticsTool('cloudflare_worker_usage', {}, client);
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('my-worker');
+      expect(client.graphql).toHaveBeenCalledWith(
+        expect.stringContaining('workersInvocationsAdaptive'),
+        expect.objectContaining({
+          accountTag: ACCOUNT_ID,
+        }),
+      );
+    });
+
+    it('uses sum_requests_DESC ordering (different from analytics)', async () => {
+      const client = mockClient();
+
+      await handleWorkerAnalyticsTool('cloudflare_worker_usage', {}, client);
+
+      const query = (client.graphql as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(query).toContain('sum_requests_DESC');
+    });
+  });
+
+  describe('unknown tool', () => {
+    it('returns unknown tool message for unrecognized tool name', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkerAnalyticsTool('cloudflare_worker_unknown', {}, client);
+
+      expect(result.content[0].text).toContain('Unknown Worker Analytics tool');
+    });
+  });
+
+  describe('API error handling', () => {
+    it('returns error message when GraphQL call fails', async () => {
+      const client = mockClient({
+        graphql: vi.fn().mockRejectedValue(new Error('GraphQL error')),
+      });
+
+      const result = await handleWorkerAnalyticsTool('cloudflare_worker_analytics', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_analytics');
+      expect(result.content[0].text).toContain('GraphQL error');
+    });
+  });
+});

--- a/tests/tools/worker-secrets.test.ts
+++ b/tests/tools/worker-secrets.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest';
+import { workerSecretsToolDefinitions, handleWorkerSecretsTool } from '../../src/tools/worker-secrets.js';
+import type { CloudflareClient } from '../../src/client/cloudflare-client.js';
+
+const ACCOUNT_ID = '00000000000000000000000000000001';
+
+function mockClient(overrides: Partial<CloudflareClient> = {}): CloudflareClient {
+  return {
+    get: vi.fn().mockResolvedValue([]),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    resolveZoneId: vi.fn().mockResolvedValue('00000000000000000000000000000002'),
+    getRaw: vi.fn().mockResolvedValue(''),
+    getWithHeaders: vi.fn().mockResolvedValue({ result: [], headers: {} }),
+    postForm: vi.fn().mockResolvedValue({}),
+    putForm: vi.fn().mockResolvedValue({}),
+    putRaw: vi.fn().mockResolvedValue(undefined),
+    graphql: vi.fn().mockResolvedValue({}),
+    getAccountId: vi.fn().mockReturnValue(ACCOUNT_ID),
+    ...overrides,
+  } as unknown as CloudflareClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+describe('Worker Secrets Tool Definitions', () => {
+  it('exports 3 tool definitions', () => {
+    expect(workerSecretsToolDefinitions).toHaveLength(3);
+  });
+
+  it('all tools have cloudflare_worker_secret_ prefix', () => {
+    for (const tool of workerSecretsToolDefinitions) {
+      expect(tool.name).toMatch(/^cloudflare_worker_secret_/);
+    }
+  });
+
+  it('all tools have non-empty descriptions', () => {
+    for (const tool of workerSecretsToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('all tools have inputSchema with type object', () => {
+    for (const tool of workerSecretsToolDefinitions) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleWorkerSecretsTool
+// ---------------------------------------------------------------------------
+
+describe('handleWorkerSecretsTool', () => {
+  describe('cloudflare_worker_secret_list', () => {
+    it('lists secrets for a worker', async () => {
+      const mockSecrets = [{ name: 'API_KEY', type: 'secret_text' }];
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockSecrets) });
+
+      const result = await handleWorkerSecretsTool(
+        'cloudflare_worker_secret_list',
+        { script_name: 'my-worker' },
+        client,
+      );
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('API_KEY');
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/workers/scripts/my-worker/secrets`,
+      );
+    });
+
+    it('requires script_name', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkerSecretsTool('cloudflare_worker_secret_list', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_secret_list');
+    });
+
+    it('returns error when account_id is missing', async () => {
+      const client = mockClient({ getAccountId: vi.fn().mockReturnValue(undefined) });
+
+      const result = await handleWorkerSecretsTool(
+        'cloudflare_worker_secret_list',
+        { script_name: 'my-worker' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('CLOUDFLARE_ACCOUNT_ID');
+    });
+  });
+
+  describe('cloudflare_worker_secret_set', () => {
+    it('sets a secret and does NOT echo the value', async () => {
+      const client = mockClient({ put: vi.fn().mockResolvedValue({}) });
+
+      const result = await handleWorkerSecretsTool(
+        'cloudflare_worker_secret_set',
+        { script_name: 'my-worker', secret_name: 'DB_PASSWORD', secret_value: 'super-secret-123' },
+        client,
+      );
+
+      // Verify the API call
+      expect(client.put).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/workers/scripts/my-worker/secrets`,
+        { name: 'DB_PASSWORD', text: 'super-secret-123', type: 'secret_text' },
+      );
+
+      // CRITICAL: verify the response does NOT contain the secret value
+      expect(result.content[0].text).not.toContain('super-secret-123');
+      expect(result.content[0].text).toContain('success');
+      expect(result.content[0].text).toContain('DB_PASSWORD');
+      expect(result.content[0].text).toContain('not returned for security');
+    });
+
+    it('requires script_name and secret_name and secret_value', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkerSecretsTool(
+        'cloudflare_worker_secret_set',
+        { script_name: 'my-worker' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_secret_set');
+    });
+
+    it('rejects invalid script_name', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkerSecretsTool(
+        'cloudflare_worker_secret_set',
+        { script_name: 'INVALID', secret_name: 'KEY', secret_value: 'val' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_secret_set');
+    });
+  });
+
+  describe('cloudflare_worker_secret_delete', () => {
+    it('deletes a secret', async () => {
+      const client = mockClient({ delete: vi.fn().mockResolvedValue({}) });
+
+      await handleWorkerSecretsTool(
+        'cloudflare_worker_secret_delete',
+        { script_name: 'my-worker', secret_name: 'OLD_KEY' },
+        client,
+      );
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/workers/scripts/my-worker/secrets/OLD_KEY`,
+      );
+    });
+
+    it('requires script_name and secret_name', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkerSecretsTool(
+        'cloudflare_worker_secret_delete',
+        { script_name: 'my-worker' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_secret_delete');
+    });
+  });
+
+  describe('unknown tool', () => {
+    it('returns unknown tool message for unrecognized tool name', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkerSecretsTool('cloudflare_worker_secret_unknown', {}, client);
+
+      expect(result.content[0].text).toContain('Unknown Worker Secrets tool');
+    });
+  });
+
+  describe('API error handling', () => {
+    it('returns error message when API call fails', async () => {
+      const client = mockClient({
+        get: vi.fn().mockRejectedValue(new Error('API request failed')),
+      });
+
+      const result = await handleWorkerSecretsTool(
+        'cloudflare_worker_secret_list',
+        { script_name: 'my-worker' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_secret_list');
+      expect(result.content[0].text).toContain('API request failed');
+    });
+  });
+});

--- a/tests/tools/workers.test.ts
+++ b/tests/tools/workers.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi } from 'vitest';
+import { workersToolDefinitions, handleWorkersTool } from '../../src/tools/workers.js';
+import type { CloudflareClient } from '../../src/client/cloudflare-client.js';
+
+const ACCOUNT_ID = '00000000000000000000000000000001';
+const ZONE_ID = '00000000000000000000000000000002';
+
+function mockClient(overrides: Partial<CloudflareClient> = {}): CloudflareClient {
+  return {
+    get: vi.fn().mockResolvedValue([]),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    resolveZoneId: vi.fn().mockResolvedValue(ZONE_ID),
+    getRaw: vi.fn().mockResolvedValue(''),
+    getWithHeaders: vi.fn().mockResolvedValue({ result: [], headers: {} }),
+    postForm: vi.fn().mockResolvedValue({}),
+    putForm: vi.fn().mockResolvedValue({}),
+    putRaw: vi.fn().mockResolvedValue(undefined),
+    graphql: vi.fn().mockResolvedValue({}),
+    getAccountId: vi.fn().mockReturnValue(ACCOUNT_ID),
+    ...overrides,
+  } as unknown as CloudflareClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+describe('Workers Tool Definitions', () => {
+  it('exports 5 tool definitions', () => {
+    expect(workersToolDefinitions).toHaveLength(5);
+  });
+
+  it('all tools have cloudflare_worker_ prefix', () => {
+    for (const tool of workersToolDefinitions) {
+      expect(tool.name).toMatch(/^cloudflare_worker_/);
+    }
+  });
+
+  it('all tools have non-empty descriptions', () => {
+    for (const tool of workersToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('all tools have inputSchema with type object', () => {
+    for (const tool of workersToolDefinitions) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleWorkersTool
+// ---------------------------------------------------------------------------
+
+describe('handleWorkersTool', () => {
+  describe('cloudflare_worker_list', () => {
+    it('lists worker scripts', async () => {
+      const mockScripts = [{ id: 'my-worker', etag: 'abc', handlers: ['fetch'] }];
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockScripts) });
+
+      const result = await handleWorkersTool('cloudflare_worker_list', {}, client);
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('my-worker');
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/workers/scripts`,
+      );
+    });
+
+    it('returns error when account_id is missing', async () => {
+      const client = mockClient({ getAccountId: vi.fn().mockReturnValue(undefined) });
+
+      const result = await handleWorkersTool('cloudflare_worker_list', {}, client);
+
+      expect(result.content[0].text).toContain('CLOUDFLARE_ACCOUNT_ID');
+    });
+  });
+
+  describe('cloudflare_worker_deploy', () => {
+    it('deploys a worker script', async () => {
+      const mockResult = { id: 'my-worker', etag: 'def' };
+      const client = mockClient({ putForm: vi.fn().mockResolvedValue(mockResult) });
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_deploy',
+        {
+          script_name: 'my-worker',
+          script_content: 'export default { fetch() { return new Response("ok"); } }',
+          compatibility_date: '2026-03-15',
+        },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('my-worker');
+      expect(client.putForm).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/workers/scripts/my-worker`,
+        expect.any(Object),
+      );
+    });
+
+    it('requires script_name and script_content', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkersTool('cloudflare_worker_deploy', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_deploy');
+    });
+
+    it('rejects invalid script_name', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_deploy',
+        { script_name: 'INVALID_NAME', script_content: 'code', compatibility_date: '2026-03-15' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_deploy');
+    });
+  });
+
+  describe('cloudflare_worker_delete', () => {
+    it('deletes a worker script', async () => {
+      const client = mockClient({ delete: vi.fn().mockResolvedValue({}) });
+
+      await handleWorkersTool(
+        'cloudflare_worker_delete',
+        { script_name: 'old-worker' },
+        client,
+      );
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/workers/scripts/old-worker`,
+      );
+    });
+
+    it('requires script_name', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkersTool('cloudflare_worker_delete', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_delete');
+    });
+  });
+
+  describe('cloudflare_worker_route_list', () => {
+    it('lists worker routes for a zone', async () => {
+      const mockRoutes = [{ id: 'route1', pattern: '*.example.com/*', script: 'my-worker' }];
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockRoutes) });
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_route_list',
+        { zone_id: 'example.com' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('my-worker');
+      expect(client.resolveZoneId).toHaveBeenCalledWith('example.com');
+      expect(client.get).toHaveBeenCalledWith(
+        `/zones/${ZONE_ID}/workers/routes`,
+      );
+    });
+
+    it('requires zone_id', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkersTool('cloudflare_worker_route_list', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_route_list');
+    });
+  });
+
+  describe('cloudflare_worker_route_create', () => {
+    it('creates a worker route', async () => {
+      const mockRoute = { id: 'route2', pattern: 'api.example.com/*', script: 'api-worker' };
+      const client = mockClient({ post: vi.fn().mockResolvedValue(mockRoute) });
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_route_create',
+        { zone_id: 'example.com', pattern: 'api.example.com/*', script: 'api-worker' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('api-worker');
+      expect(client.resolveZoneId).toHaveBeenCalledWith('example.com');
+      expect(client.post).toHaveBeenCalledWith(
+        `/zones/${ZONE_ID}/workers/routes`,
+        { pattern: 'api.example.com/*', script: 'api-worker' },
+      );
+    });
+
+    it('requires zone_id, pattern, and script', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_route_create',
+        { zone_id: 'example.com' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_route_create');
+    });
+  });
+
+  describe('unknown tool', () => {
+    it('returns unknown tool message for unrecognized tool name', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkersTool('cloudflare_worker_unknown', {}, client);
+
+      expect(result.content[0].text).toContain('Unknown Workers tool');
+    });
+  });
+
+  describe('API error handling', () => {
+    it('returns error message when API call fails', async () => {
+      const client = mockClient({
+        get: vi.fn().mockRejectedValue(new Error('API request failed')),
+      });
+
+      const result = await handleWorkersTool('cloudflare_worker_list', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_list');
+      expect(result.content[0].text).toContain('API request failed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add 4 new tool modules expanding mcp-cloudflare from 42 to 59 tools
- Workers KV (7 tools): namespace CRUD, key read/write/delete/list (#27)
- Workers Scripts (5 tools): list, deploy, delete, route management (#28)
- Worker Secrets (3 tools): list/set/delete with security (values never exposed) (#29)
- Worker Analytics (2 tools): GraphQL invocation metrics and usage (#30)
- 2 new skills: cloudflare-kv-manage, cloudflare-worker-deploy (#31)
- Client enhancements: `putForm()`, `putRaw()` methods
- 64 new unit tests (all passing)

Closes #27, closes #28, closes #29, closes #30, closes #31

## Test plan

- [ ] `npm run build` succeeds (TypeScript clean)
- [ ] `npm test` — 203 tests pass (64 new, 2 pre-existing dns.test.ts failures unrelated)
- [ ] Tool count verified: 42 → 59
- [ ] Worker secrets tools never echo secret values in output
- [ ] Skills README and main README updated
- [ ] CHANGELOG updated
- [ ] `/cf-test kv workers` live test (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)