### PR TITLE
Add cloudflare_zt_create_app tool for Zero Trust Access apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.15.4
+
+- **Add `cloudflare_zt_create_app` tool** (#33)
+  - Create Zero Trust Access applications programmatically
+  - Supports: self_hosted, saas, ssh, vnc, bookmark app types
+  - Optional: session_duration, allowed_idps, auto_redirect, self_hosted_domains
+  - 7 new tests (required params, optional params, validation, defaults, error handling)
+  - Tool count: 59 → 60
+
 ## v2026.03.15.1
 
 - **Add Workers KV tools** (7 tools) (#27)

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Slim Cloudflare MCP Server for managing DNS, zones, tunnels, WAF, Zero Trust, an
 
 ## Features
 
-59 tools across 10 domains:
+60 tools across 10 domains:
 
 - **DNS** — Record management (A, AAAA, CNAME, MX, TXT, SRV, CAA, NS), batch operations
 - **Zones** — Zone listing, settings, SSL/TLS configuration, cache management
 - **Tunnels** — Cloudflare Tunnel creation, configuration, and ingress management
 - **WAF** — Ruleset management, custom firewall rules, rate limiting
-- **Zero Trust** — Access applications, policies, identity providers, Gateway status
+- **Zero Trust** — Access application CRUD, policies, identity providers, Gateway status
 - **Security** — Security event analytics, IP access rules, DDoS configuration
 - **Workers KV** — Namespace management, key-value read/write/delete, key listing
 - **Workers** — Script deployment, route management

--- a/src/tools/zerotrust.ts
+++ b/src/tools/zerotrust.ts
@@ -26,6 +26,25 @@ const ZtCreatePolicySchema = z.object({
     .min(1, "At least one include rule is required"),
 });
 
+const ZtAppTypeSchema = z.enum([
+  "self_hosted",
+  "saas",
+  "ssh",
+  "vnc",
+  "bookmark",
+]);
+
+const ZtCreateAppSchema = z.object({
+  name: z.string().min(1, "App name is required"),
+  domain: z.string().min(1, "Domain is required"),
+  type: ZtAppTypeSchema.default("self_hosted"),
+  session_duration: z.string().optional(),
+  allowed_idps: z.array(z.string()).optional(),
+  auto_redirect_to_identity: z.boolean().optional(),
+  app_launcher_visible: z.boolean().optional(),
+  self_hosted_domains: z.array(z.string()).optional(),
+});
+
 const ZtListIdpsSchema = z.object({});
 
 const ZtGatewayStatusSchema = z.object({});
@@ -66,6 +85,52 @@ export const zerotrustToolDefinitions = [
         app_id: { type: "string", description: "Access application ID (UUID)" },
       },
       required: ["app_id"],
+    },
+  },
+  {
+    name: "cloudflare_zt_create_app",
+    description:
+      "Create a new Zero Trust Access application. Protects a domain with identity-based access control.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: { type: "string", description: "Application name" },
+        domain: {
+          type: "string",
+          description:
+            "Primary application domain (e.g., 'app.example.com' or 'app.example.com/path*')",
+        },
+        type: {
+          type: "string",
+          enum: ["self_hosted", "saas", "ssh", "vnc", "bookmark"],
+          description: "Application type (default: self_hosted)",
+        },
+        session_duration: {
+          type: "string",
+          description: "Session duration (e.g., '8h', '24h', '30m'). Default: 24h",
+        },
+        allowed_idps: {
+          type: "array",
+          description: "Array of IdP UUIDs to restrict login methods. Omit to allow all configured IdPs.",
+          items: { type: "string" },
+        },
+        auto_redirect_to_identity: {
+          type: "boolean",
+          description:
+            "Auto-redirect to IdP login instead of showing app launcher (default: false)",
+        },
+        app_launcher_visible: {
+          type: "boolean",
+          description: "Show in the Zero Trust App Launcher (default: true)",
+        },
+        self_hosted_domains: {
+          type: "array",
+          description:
+            "Additional domains for this app (multi-domain). Primary domain is always included.",
+          items: { type: "string" },
+        },
+      },
+      required: ["name", "domain"],
     },
   },
   {
@@ -147,6 +212,31 @@ export async function handleZerotrustTool(
         const accountId = requireAccountId(client);
         const result = await client.get(
           `/accounts/${accountId}/access/apps/${parsed.app_id}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_zt_create_app": {
+        const parsed = ZtCreateAppSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const body: Record<string, unknown> = {
+          name: parsed.name,
+          domain: parsed.domain,
+          type: parsed.type,
+        };
+        if (parsed.session_duration !== undefined)
+          body["session_duration"] = parsed.session_duration;
+        if (parsed.allowed_idps !== undefined)
+          body["allowed_idps"] = parsed.allowed_idps;
+        if (parsed.auto_redirect_to_identity !== undefined)
+          body["auto_redirect_to_identity"] = parsed.auto_redirect_to_identity;
+        if (parsed.app_launcher_visible !== undefined)
+          body["app_launcher_visible"] = parsed.app_launcher_visible;
+        if (parsed.self_hosted_domains !== undefined)
+          body["self_hosted_domains"] = parsed.self_hosted_domains;
+        const result = await client.post(
+          `/accounts/${accountId}/access/apps`,
+          body,
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }

--- a/tests/tools/zerotrust.test.ts
+++ b/tests/tools/zerotrust.test.ts
@@ -28,8 +28,8 @@ function mockClient(overrides: Partial<CloudflareClient> = {}): CloudflareClient
 // ---------------------------------------------------------------------------
 
 describe('Zero Trust Tool Definitions', () => {
-  it('exports 6 tool definitions', () => {
-    expect(zerotrustToolDefinitions).toHaveLength(6);
+  it('exports 7 tool definitions', () => {
+    expect(zerotrustToolDefinitions).toHaveLength(7);
   });
 
   it('all tools have cloudflare_zt_ prefix', () => {
@@ -101,6 +101,125 @@ describe('handleZerotrustTool', () => {
       const result = await handleZerotrustTool('cloudflare_zt_get_app', {}, client);
 
       expect(result.content[0].text).toContain('Error executing cloudflare_zt_get_app');
+    });
+  });
+
+  describe('cloudflare_zt_create_app', () => {
+    it('creates a self_hosted app with required params only', async () => {
+      const mockApp = { id: APP_ID, name: 'UAT App', domain: 'uat.example.com', type: 'self_hosted' };
+      const client = mockClient({ post: vi.fn().mockResolvedValue(mockApp) });
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_app',
+        { name: 'UAT App', domain: 'uat.example.com' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('UAT App');
+      expect(client.post).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/access/apps`,
+        { name: 'UAT App', domain: 'uat.example.com', type: 'self_hosted' },
+      );
+    });
+
+    it('creates an app with all optional params', async () => {
+      const IDP_ID = 'a2aefb8b-65f3-4d5e-80c0-0dd046ddc4b2';
+      const mockApp = { id: APP_ID, name: 'Full App', domain: 'app.example.com' };
+      const client = mockClient({ post: vi.fn().mockResolvedValue(mockApp) });
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_app',
+        {
+          name: 'Full App',
+          domain: 'app.example.com',
+          type: 'self_hosted',
+          session_duration: '8h',
+          allowed_idps: [IDP_ID],
+          auto_redirect_to_identity: true,
+          app_launcher_visible: true,
+          self_hosted_domains: ['app.example.com', 'app2.example.com'],
+        },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Full App');
+      expect(client.post).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/access/apps`,
+        {
+          name: 'Full App',
+          domain: 'app.example.com',
+          type: 'self_hosted',
+          session_duration: '8h',
+          allowed_idps: [IDP_ID],
+          auto_redirect_to_identity: true,
+          app_launcher_visible: true,
+          self_hosted_domains: ['app.example.com', 'app2.example.com'],
+        },
+      );
+    });
+
+    it('requires name parameter', async () => {
+      const client = mockClient();
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_app',
+        { domain: 'app.example.com' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_zt_create_app');
+    });
+
+    it('requires domain parameter', async () => {
+      const client = mockClient();
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_app',
+        { name: 'My App' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_zt_create_app');
+    });
+
+    it('rejects invalid app type', async () => {
+      const client = mockClient();
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_app',
+        { name: 'My App', domain: 'app.example.com', type: 'invalid' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_zt_create_app');
+    });
+
+    it('defaults type to self_hosted when omitted', async () => {
+      const mockApp = { id: APP_ID, name: 'Default Type', domain: 'app.example.com' };
+      const client = mockClient({ post: vi.fn().mockResolvedValue(mockApp) });
+
+      await handleZerotrustTool(
+        'cloudflare_zt_create_app',
+        { name: 'Default Type', domain: 'app.example.com' },
+        client,
+      );
+
+      expect(client.post).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/access/apps`,
+        expect.objectContaining({ type: 'self_hosted' }),
+      );
+    });
+
+    it('returns error when account_id is missing', async () => {
+      const client = mockClient({ getAccountId: vi.fn().mockReturnValue(undefined) });
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_app',
+        { name: 'My App', domain: 'app.example.com' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('CLOUDFLARE_ACCOUNT_ID');
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `cloudflare_zt_create_app` tool to create Zero Trust Access applications programmatically
- Tool count: 59 → 60

### Parameters
| Param | Required | Description |
|-------|----------|-------------|
| `name` | Yes | Application name |
| `domain` | Yes | Primary domain (e.g., `app.example.com`) |
| `type` | No | App type: self_hosted (default), saas, ssh, vnc, bookmark |
| `session_duration` | No | Session lifetime (e.g., `8h`, `24h`) |
| `allowed_idps` | No | Restrict to specific IdP UUIDs |
| `auto_redirect_to_identity` | No | Auto-redirect to IdP login |
| `app_launcher_visible` | No | Show in App Launcher |
| `self_hosted_domains` | No | Additional domains for multi-domain apps |

### Tests (7 new)
- Creates app with required params only
- Creates app with all optional params
- Validates required name/domain
- Rejects invalid app type
- Defaults type to self_hosted
- Returns error when account_id missing

## Test plan
- [x] `npm run build` — zero TypeScript errors
- [x] `npm test` — 7 new tests pass (2 pre-existing dns.test.ts failures unrelated)
- [x] README tool count updated (59→60)
- [x] CHANGELOG updated

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)