### PR TITLE
feat: add wrangler-based project deployment tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.16.1
+
+- **Add `cloudflare_worker_deploy_project` tool** (#35)
+  - Deploy multi-file TypeScript Workers projects using wrangler
+  - Parameters: `project_path` (required), `environment` (optional, e.g., 'uat', 'production')
+  - Uses `execFileSync` (no shell invocation) for security
+  - Validates project directory and wrangler.toml existence before deployment
+  - Passes `CLOUDFLARE_API_TOKEN` from MCP server environment
+  - 6 new tests (deploy, env flag, missing dir, missing toml, missing params, exec errors)
+  - Tool count: 60 → 61
+
 ## v2026.03.15.4
 
 - **Add `cloudflare_zt_create_app` tool** (#33)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified/mcp-cloudflare",
-  "version": "2026.3.14",
+  "version": "2026.3.16",
   "description": "Slim Cloudflare MCP Server — DNS, Zones, Tunnels, WAF, Zero Trust, Security management via Cloudflare API v4",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ for (const def of workerSecretsToolDefinitions) toolHandlers.set(def.name, handl
 for (const def of workerAnalyticsToolDefinitions) toolHandlers.set(def.name, handleWorkerAnalyticsTool);
 
 const server = new Server(
-  { name: 'mcp-cloudflare', version: '2026.3.13' },
+  { name: 'mcp-cloudflare', version: '2026.3.16' },
   { capabilities: { tools: {} } }
 );
 

--- a/src/tools/workers.ts
+++ b/src/tools/workers.ts
@@ -1,3 +1,6 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { z } from "zod";
 import type { CloudflareClient } from "../client/cloudflare-client.js";
 import { ScriptNameSchema, ZoneNameOrIdSchema } from "../utils/validation.js";
@@ -28,6 +31,11 @@ const WorkerRouteCreateSchema = z.object({
   zone_id: ZoneNameOrIdSchema,
   pattern: z.string().min(1, "Route pattern is required"),
   script: ScriptNameSchema,
+});
+
+const WorkerDeployProjectSchema = z.object({
+  project_path: z.string().min(1, "Project path is required"),
+  environment: z.string().optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -121,6 +129,27 @@ export const workersToolDefinitions = [
       required: ["zone_id", "pattern", "script"],
     },
   },
+  {
+    name: "cloudflare_worker_deploy_project",
+    description:
+      "Deploy a multi-file Workers project using wrangler. Runs 'npx wrangler deploy' in the given project directory. " +
+      "Requires wrangler installed in the project (devDependency) and a wrangler.toml config file. " +
+      "Uses the CLOUDFLARE_API_TOKEN from the MCP server environment.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        project_path: {
+          type: "string",
+          description: "Absolute path to the Workers project directory containing wrangler.toml",
+        },
+        environment: {
+          type: "string",
+          description: "Optional wrangler environment name (e.g., 'uat', 'production'). Maps to [env.<name>] in wrangler.toml",
+        },
+      },
+      required: ["project_path"],
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -187,6 +216,50 @@ export async function handleWorkersTool(
           { pattern: parsed.pattern, script: parsed.script },
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_worker_deploy_project": {
+        const parsed = WorkerDeployProjectSchema.parse(args);
+        const projectPath = resolve(parsed.project_path);
+
+        // Validate project directory exists
+        if (!existsSync(projectPath)) {
+          throw new Error(`Project directory does not exist: ${projectPath}`);
+        }
+
+        // Validate wrangler.toml exists
+        const wranglerToml = resolve(projectPath, "wrangler.toml");
+        if (!existsSync(wranglerToml)) {
+          throw new Error(`wrangler.toml not found in ${projectPath}`);
+        }
+
+        // Build args array for execFileSync (no shell — prevents injection)
+        const wranglerArgs = ["wrangler", "deploy"];
+        if (parsed.environment) {
+          wranglerArgs.push("--env", parsed.environment);
+        }
+
+        // Pass CLOUDFLARE_API_TOKEN from the MCP server's environment
+        const deployEnv: Record<string, string> = { ...(process.env as Record<string, string>) };
+        const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+        if (apiToken) {
+          deployEnv.CLOUDFLARE_API_TOKEN = apiToken;
+        }
+
+        // execFileSync with npx binary — no shell invocation
+        const output = execFileSync("npx", wranglerArgs, {
+          cwd: projectPath,
+          env: deployEnv,
+          encoding: "utf-8",
+          timeout: 120_000, // 2 minute timeout
+        });
+
+        return {
+          content: [{
+            type: "text",
+            text: `Deployed successfully from ${projectPath}${parsed.environment ? ` (env: ${parsed.environment})` : ""}:\n\n${output}`,
+          }],
+        };
       }
 
       default:

--- a/tests/tools/workers.test.ts
+++ b/tests/tools/workers.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { workersToolDefinitions, handleWorkersTool } from '../../src/tools/workers.js';
 import type { CloudflareClient } from '../../src/client/cloudflare-client.js';
+
+// Mock child_process and fs for deploy_project tests
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn().mockReturnValue('Worker deployed successfully\nhttps://landing-page.workers.dev'),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+}));
 
 const ACCOUNT_ID = '00000000000000000000000000000001';
 const ZONE_ID = '00000000000000000000000000000002';
@@ -29,8 +38,8 @@ function mockClient(overrides: Partial<CloudflareClient> = {}): CloudflareClient
 // ---------------------------------------------------------------------------
 
 describe('Workers Tool Definitions', () => {
-  it('exports 5 tool definitions', () => {
-    expect(workersToolDefinitions).toHaveLength(5);
+  it('exports 6 tool definitions', () => {
+    expect(workersToolDefinitions).toHaveLength(6);
   });
 
   it('all tools have cloudflare_worker_ prefix', () => {
@@ -205,6 +214,114 @@ describe('handleWorkersTool', () => {
       );
 
       expect(result.content[0].text).toContain('Error executing cloudflare_worker_route_create');
+    });
+  });
+
+  describe('cloudflare_worker_deploy_project', () => {
+    let execFileSyncMock: ReturnType<typeof vi.fn>;
+    let existsSyncMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      const childProcess = await import('node:child_process');
+      const fs = await import('node:fs');
+      execFileSyncMock = childProcess.execFileSync as unknown as ReturnType<typeof vi.fn>;
+      existsSyncMock = fs.existsSync as unknown as ReturnType<typeof vi.fn>;
+      execFileSyncMock.mockReturnValue('Worker deployed successfully\nhttps://landing-page.workers.dev');
+      existsSyncMock.mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('deploys a wrangler project', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_deploy_project',
+        { project_path: '/tmp/my-worker' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Deployed successfully');
+      expect(result.content[0].text).toContain('landing-page.workers.dev');
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'npx',
+        ['wrangler', 'deploy'],
+        expect.objectContaining({ cwd: '/tmp/my-worker' }),
+      );
+    });
+
+    it('passes environment flag when specified', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_deploy_project',
+        { project_path: '/tmp/my-worker', environment: 'uat' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('env: uat');
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'npx',
+        ['wrangler', 'deploy', '--env', 'uat'],
+        expect.objectContaining({ cwd: '/tmp/my-worker' }),
+      );
+    });
+
+    it('errors when project directory does not exist', async () => {
+      existsSyncMock.mockReturnValue(false);
+      const client = mockClient();
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_deploy_project',
+        { project_path: '/tmp/nonexistent' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('does not exist');
+    });
+
+    it('errors when wrangler.toml is missing', async () => {
+      // First call (project dir) returns true, second call (wrangler.toml) returns false
+      existsSyncMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
+      const client = mockClient();
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_deploy_project',
+        { project_path: '/tmp/no-toml' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('wrangler.toml not found');
+    });
+
+    it('requires project_path', async () => {
+      const client = mockClient();
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_deploy_project',
+        {},
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_deploy_project');
+    });
+
+    it('handles wrangler execution errors', async () => {
+      execFileSyncMock.mockImplementation(() => {
+        throw new Error('wrangler deploy failed: authentication error');
+      });
+      const client = mockClient();
+
+      const result = await handleWorkersTool(
+        'cloudflare_worker_deploy_project',
+        { project_path: '/tmp/my-worker' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_worker_deploy_project');
+      expect(result.content[0].text).toContain('authentication error');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds `cloudflare_worker_deploy_project` tool that deploys multi-file TypeScript Workers projects using wrangler.

Closes #35

## Changes

- New tool: `cloudflare_worker_deploy_project` with `project_path` and optional `environment` parameters
- Uses `execFileSync("npx", ["wrangler", "deploy", ...])` — no shell invocation (prevents command injection)
- Validates project directory and wrangler.toml existence before deployment
- Passes `CLOUDFLARE_API_TOKEN` from MCP server environment
- 6 new unit tests covering: deploy, env flag, missing dir, missing toml, missing params, exec errors
- Tool count: 60 → 61
- CHANGELOG updated, version bumped to 2026.3.16

## Test plan

- [x] Unit tests pass (23 worker tests)
- [x] Build succeeds
- [ ] Live test: deploy a wrangler project via MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)