### PR TITLE
fix: coerce boolean parameters from MCP string serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.16.2
+
+- **Fix boolean parameter validation across 6 tools** (#37)
+  - MCP protocol sends boolean params as strings ("true"/"false"), Zod `z.boolean()` rejects them
+  - Add `CoercedBooleanSchema` to `src/utils/validation.ts` using `z.preprocess()` for string→boolean coercion
+  - Fixed tools: `cloudflare_dns_list`, `cloudflare_dns_create`, `cloudflare_dns_update` (proxied), `cloudflare_tunnel_list` (is_deleted), `cloudflare_zt_create_app` (auto_redirect_to_identity, app_launcher_visible), `cloudflare_zone_setting_update` (value union)
+  - Updated shared `ProxiedSchema` to use `CoercedBooleanSchema`
+
 ## v2026.03.16.1
 
 - **Add `cloudflare_worker_deploy_project` tool** (#35)

--- a/src/tools/dns.ts
+++ b/src/tools/dns.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { CloudflareClient } from "../client/cloudflare-client.js";
 import type { DnsRecord } from "../client/types.js";
-import { ZoneNameOrIdSchema, RecordIdSchema, DnsRecordTypeSchema, TtlSchema } from "../utils/validation.js";
+import { ZoneNameOrIdSchema, RecordIdSchema, DnsRecordTypeSchema, TtlSchema, CoercedBooleanSchema } from "../utils/validation.js";
 
 // ---------------------------------------------------------------------------
 // Zod schemas for input validation
@@ -12,7 +12,7 @@ const DnsListSchema = z.object({
   type: DnsRecordTypeSchema.optional(),
   name: z.string().optional(),
   content: z.string().optional(),
-  proxied: z.boolean().optional(),
+  proxied: CoercedBooleanSchema.optional(),
   page: z.number().int().min(1).optional(),
   per_page: z.number().int().min(1).max(5000).optional(),
 });
@@ -27,7 +27,7 @@ const DnsCreateSchema = z.object({
   type: DnsRecordTypeSchema,
   name: z.string().min(1, "Record name is required"),
   content: z.string().min(1, "Record content is required"),
-  proxied: z.boolean().optional(),
+  proxied: CoercedBooleanSchema.optional(),
   ttl: TtlSchema.optional(),
   priority: z.number().int().min(0).max(65535).optional(),
 });
@@ -38,7 +38,7 @@ const DnsUpdateSchema = z.object({
   type: DnsRecordTypeSchema,
   name: z.string().min(1, "Record name is required"),
   content: z.string().min(1, "Record content is required"),
-  proxied: z.boolean().optional(),
+  proxied: CoercedBooleanSchema.optional(),
   ttl: TtlSchema.optional(),
   priority: z.number().int().min(0).max(65535).optional(),
 });

--- a/src/tools/tunnels.ts
+++ b/src/tools/tunnels.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { randomBytes } from "crypto";
 import type { CloudflareClient } from "../client/cloudflare-client.js";
-import { TunnelIdSchema } from "../utils/validation.js";
+import { TunnelIdSchema, CoercedBooleanSchema } from "../utils/validation.js";
 
 // ---------------------------------------------------------------------------
 // Zod schemas for input validation
@@ -11,7 +11,7 @@ const TunnelListSchema = z.object({
   page: z.number().int().min(1).optional(),
   per_page: z.number().int().min(1).max(100).optional(),
   name: z.string().optional(),
-  is_deleted: z.boolean().optional(),
+  is_deleted: CoercedBooleanSchema.optional(),
 });
 
 const TunnelGetSchema = z.object({

--- a/src/tools/zerotrust.ts
+++ b/src/tools/zerotrust.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { CloudflareClient } from "../client/cloudflare-client.js";
+import { CoercedBooleanSchema } from "../utils/validation.js";
 
 // ---------------------------------------------------------------------------
 // Zod schemas for input validation
@@ -40,8 +41,8 @@ const ZtCreateAppSchema = z.object({
   type: ZtAppTypeSchema.default("self_hosted"),
   session_duration: z.string().optional(),
   allowed_idps: z.array(z.string()).optional(),
-  auto_redirect_to_identity: z.boolean().optional(),
-  app_launcher_visible: z.boolean().optional(),
+  auto_redirect_to_identity: CoercedBooleanSchema.optional(),
+  app_launcher_visible: CoercedBooleanSchema.optional(),
   self_hosted_domains: z.array(z.string()).optional(),
 });
 

--- a/src/tools/zones.ts
+++ b/src/tools/zones.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { CloudflareClient } from "../client/cloudflare-client.js";
-import { ZoneNameOrIdSchema } from "../utils/validation.js";
+import { ZoneNameOrIdSchema, CoercedBooleanSchema } from "../utils/validation.js";
 
 // ---------------------------------------------------------------------------
 // Zod schemas for input validation
@@ -25,7 +25,7 @@ const ZoneSettingGetSchema = z.object({
 const ZoneSettingUpdateSchema = z.object({
   zone_id: ZoneNameOrIdSchema,
   setting_name: z.string().min(1, "Setting name is required"),
-  value: z.union([z.string(), z.number(), z.boolean(), z.record(z.unknown()), z.array(z.unknown())]),
+  value: z.union([z.string(), z.number(), CoercedBooleanSchema, z.record(z.unknown()), z.array(z.unknown())]),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -60,8 +60,17 @@ export const TtlSchema = z
     "TTL must be 1 (auto) or between 60 and 86400 seconds",
   );
 
+/**
+ * Boolean schema that accepts both native booleans and string representations.
+ * MCP protocol may send boolean parameters as strings ("true"/"false").
+ */
+export const CoercedBooleanSchema = z.preprocess((v) => {
+  if (typeof v === "string") return v === "true";
+  return v;
+}, z.boolean());
+
 /** Whether a DNS record is proxied through Cloudflare */
-export const ProxiedSchema = z.boolean();
+export const ProxiedSchema = CoercedBooleanSchema;
 
 /** 32-character hex string used as Cloudflare account IDs */
 export const AccountIdSchema = z


### PR DESCRIPTION
## Summary
- MCP protocol sends tool parameters as strings, but Zod `z.boolean()` rejects `"true"`/`"false"` strings with validation error
- Add shared `CoercedBooleanSchema` using `z.preprocess()` for string→boolean coercion
- Fix 6 tools across 4 files: dns_list, dns_create, dns_update, tunnel_list, zt_create_app, zone_setting_update

Closes #37

## Test plan
- [x] Build passes (`npm run build`)
- [x] Existing tests pass (216/218 — 2 pre-existing failures in dns_search unrelated to this fix)
- [ ] Live test: `cloudflare_dns_create` with `proxied: true` succeeds
- [ ] Live test: `cloudflare_dns_update` with `proxied: true` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)