### PR TITLE
feat: add cloudflare_zt_create_idp tool (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.16.3
+
+- **Add `cloudflare_zt_create_idp` tool for Zero Trust IdP management** (#39)
+  - Create identity providers: GitHub, Google, SAML, OIDC, Azure AD, Okta, one-time PIN
+  - `client_secret` automatically redacted in response output (security)
+  - Zod validation for all parameters including IdP type enum
+  - 5 unit tests covering success, validation errors, missing account ID
+
 ## v2026.03.16.2
 
 - **Fix boolean parameter validation across 6 tools** (#37)

--- a/src/tools/zerotrust.ts
+++ b/src/tools/zerotrust.ts
@@ -48,6 +48,25 @@ const ZtCreateAppSchema = z.object({
 
 const ZtListIdpsSchema = z.object({});
 
+const ZtIdpTypeSchema = z.enum([
+  "github",
+  "google",
+  "saml",
+  "oidc",
+  "onetimepin",
+  "azureAD",
+  "okta",
+]);
+
+const ZtCreateIdpSchema = z.object({
+  name: z.string().min(1, "IdP name is required"),
+  type: ZtIdpTypeSchema,
+  config: z.object({
+    client_id: z.string().optional(),
+    client_secret: z.string().optional(),
+  }).passthrough(),
+});
+
 const ZtGatewayStatusSchema = z.object({});
 
 // ---------------------------------------------------------------------------
@@ -180,6 +199,32 @@ export const zerotrustToolDefinitions = [
     },
   },
   {
+    name: "cloudflare_zt_create_idp",
+    description:
+      "Create a new identity provider (IdP) for Zero Trust Access. Supports GitHub, Google, SAML, OIDC, Azure AD, Okta, and one-time PIN.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: { type: "string", description: "IdP display name (e.g., 'my-github-idp')" },
+        type: {
+          type: "string",
+          enum: ["github", "google", "saml", "oidc", "onetimepin", "azureAD", "okta"],
+          description: "Identity provider type",
+        },
+        config: {
+          type: "object",
+          description:
+            "Provider-specific configuration. For GitHub/Google/OIDC/Azure AD: { client_id, client_secret }. For SAML: { issuer_url, sso_target_url, attributes, ... }. For onetimepin: empty object {}.",
+          properties: {
+            client_id: { type: "string", description: "OAuth client ID" },
+            client_secret: { type: "string", description: "OAuth client secret" },
+          },
+        },
+      },
+      required: ["name", "type", "config"],
+    },
+  },
+  {
     name: "cloudflare_zt_gateway_status",
     description:
       "Get the Zero Trust Gateway (DNS/HTTP filtering) configuration status for the account.",
@@ -270,6 +315,25 @@ export async function handleZerotrustTool(
         const accountId = requireAccountId(client);
         const result = await client.get(`/accounts/${accountId}/access/identity_providers`);
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_zt_create_idp": {
+        const parsed = ZtCreateIdpSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.post(
+          `/accounts/${accountId}/access/identity_providers`,
+          {
+            name: parsed.name,
+            type: parsed.type,
+            config: parsed.config,
+          },
+        );
+        // Strip client_secret from response to avoid leaking it
+        const sanitized = JSON.parse(JSON.stringify(result));
+        if (sanitized?.config?.client_secret) {
+          sanitized.config.client_secret = "<redacted>";
+        }
+        return { content: [{ type: "text", text: JSON.stringify(sanitized, null, 2) }] };
       }
 
       case "cloudflare_zt_gateway_status": {

--- a/tests/tools/zerotrust.test.ts
+++ b/tests/tools/zerotrust.test.ts
@@ -28,8 +28,8 @@ function mockClient(overrides: Partial<CloudflareClient> = {}): CloudflareClient
 // ---------------------------------------------------------------------------
 
 describe('Zero Trust Tool Definitions', () => {
-  it('exports 7 tool definitions', () => {
-    expect(zerotrustToolDefinitions).toHaveLength(7);
+  it('exports 8 tool definitions', () => {
+    expect(zerotrustToolDefinitions).toHaveLength(8);
   });
 
   it('all tools have cloudflare_zt_ prefix', () => {
@@ -317,6 +317,89 @@ describe('handleZerotrustTool', () => {
       expect(client.get).toHaveBeenCalledWith(
         `/accounts/${ACCOUNT_ID}/access/identity_providers`,
       );
+    });
+  });
+
+  describe('cloudflare_zt_create_idp', () => {
+    it('creates a GitHub IdP with client credentials', async () => {
+      const mockIdp = {
+        id: 'new-idp-id',
+        name: 'my-github-idp',
+        type: 'github',
+        config: { client_id: 'gh-client-id', client_secret: 'gh-secret-value', redirect_url: 'https://team.cloudflareaccess.com/cdn-cgi/access/callback' },
+      };
+      const client = mockClient({ post: vi.fn().mockResolvedValue(mockIdp) });
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_idp',
+        {
+          name: 'my-github-idp',
+          type: 'github',
+          config: { client_id: 'gh-client-id', client_secret: 'gh-secret-value' },
+        },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('my-github-idp');
+      expect(result.content[0].text).toContain('<redacted>');
+      expect(result.content[0].text).not.toContain('gh-secret-value');
+      expect(client.post).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/access/identity_providers`,
+        {
+          name: 'my-github-idp',
+          type: 'github',
+          config: { client_id: 'gh-client-id', client_secret: 'gh-secret-value' },
+        },
+      );
+    });
+
+    it('creates a one-time PIN IdP with empty config', async () => {
+      const mockIdp = { id: 'otp-idp-id', name: 'email-otp', type: 'onetimepin', config: {} };
+      const client = mockClient({ post: vi.fn().mockResolvedValue(mockIdp) });
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_idp',
+        { name: 'email-otp', type: 'onetimepin', config: {} },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('email-otp');
+    });
+
+    it('requires name parameter', async () => {
+      const client = mockClient();
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_idp',
+        { type: 'github', config: { client_id: 'id', client_secret: 'secret' } },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_zt_create_idp');
+    });
+
+    it('rejects invalid IdP type', async () => {
+      const client = mockClient();
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_idp',
+        { name: 'test', type: 'invalid-type', config: {} },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_zt_create_idp');
+    });
+
+    it('returns error when account_id is missing', async () => {
+      const client = mockClient({ getAccountId: vi.fn().mockReturnValue(undefined) });
+
+      const result = await handleZerotrustTool(
+        'cloudflare_zt_create_idp',
+        { name: 'test', type: 'github', config: { client_id: 'id', client_secret: 'secret' } },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('CLOUDFLARE_ACCOUNT_ID');
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `cloudflare_zt_create_idp` tool to create Zero Trust identity providers
- Supports: GitHub, Google, SAML, OIDC, Azure AD, Okta, one-time PIN
- `client_secret` redacted in response output (security)
- 5 unit tests added

Closes #39

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] ZT tests pass (29/29)
- [ ] Live test: create GitHub IdP via MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)