### PR TITLE
feat: add Web Analytics (RUM) tools (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.16.4
+
+- **Add Web Analytics (RUM) tools** (#41)
+  - 5 new tools: `cloudflare_web_analytics_list`, `cloudflare_web_analytics_create`, `cloudflare_web_analytics_get`, `cloudflare_web_analytics_delete`, `cloudflare_web_analytics_stats`
+  - CRUD via REST API (`/accounts/{id}/rum/site_info`)
+  - Stats via GraphQL (`httpRequestsAdaptiveGroups`) with configurable time range and limit
+  - 19 unit tests covering all tools, validation errors, and API error handling
+
 ## v2026.03.16.3
 
 - **Add `cloudflare_zt_create_idp` tool for Zero Trust IdP management** (#39)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { kvToolDefinitions, handleKvTool } from './tools/kv.js';
 import { workersToolDefinitions, handleWorkersTool } from './tools/workers.js';
 import { workerSecretsToolDefinitions, handleWorkerSecretsTool } from './tools/worker-secrets.js';
 import { workerAnalyticsToolDefinitions, handleWorkerAnalyticsTool } from './tools/worker-analytics.js';
+import { webAnalyticsToolDefinitions, handleWebAnalyticsTool } from './tools/web-analytics.js';
 
 const allToolDefinitions: Tool[] = ([
   ...zonesToolDefinitions,
@@ -30,6 +31,7 @@ const allToolDefinitions: Tool[] = ([
   ...workersToolDefinitions,
   ...workerSecretsToolDefinitions,
   ...workerAnalyticsToolDefinitions,
+  ...webAnalyticsToolDefinitions,
 ] as unknown) as Tool[];
 
 const toolHandlers = new Map<
@@ -48,9 +50,10 @@ for (const def of kvToolDefinitions) toolHandlers.set(def.name, handleKvTool);
 for (const def of workersToolDefinitions) toolHandlers.set(def.name, handleWorkersTool);
 for (const def of workerSecretsToolDefinitions) toolHandlers.set(def.name, handleWorkerSecretsTool);
 for (const def of workerAnalyticsToolDefinitions) toolHandlers.set(def.name, handleWorkerAnalyticsTool);
+for (const def of webAnalyticsToolDefinitions) toolHandlers.set(def.name, handleWebAnalyticsTool);
 
 const server = new Server(
-  { name: 'mcp-cloudflare', version: '2026.3.16' },
+  { name: 'mcp-cloudflare', version: '2026.3.16.4' },
   { capabilities: { tools: {} } }
 );
 

--- a/src/tools/web-analytics.ts
+++ b/src/tools/web-analytics.ts
@@ -1,0 +1,250 @@
+import { z } from "zod";
+import type { CloudflareClient } from "../client/cloudflare-client.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const WebAnalyticsListSchema = z.object({
+  order_by: z.enum(["host", "created"]).optional(),
+});
+
+const WebAnalyticsCreateSchema = z.object({
+  host: z.string().min(1),
+  zone_tag: z.string().optional(),
+  auto_install: z.boolean().optional(),
+});
+
+const WebAnalyticsDeleteSchema = z.object({
+  site_id: z.string().min(1),
+});
+
+const WebAnalyticsGetSchema = z.object({
+  site_id: z.string().min(1),
+});
+
+const WebAnalyticsStatsSchema = z.object({
+  zone_id: z.string().min(1),
+  since: z.string().datetime({ offset: true }).optional(),
+  limit: z.number().int().min(1).max(10000).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// GraphQL query for Web Analytics stats
+// ---------------------------------------------------------------------------
+
+const WEB_ANALYTICS_STATS_QUERY = `
+query WebAnalyticsStats($zoneTag: string!, $since: Time!, $limit: Int!) {
+  viewer {
+    zones(filter: { zoneTag: $zoneTag }) {
+      httpRequestsAdaptiveGroups(
+        filter: { datetime_gt: $since }
+        limit: $limit
+        orderBy: [datetime_DESC]
+      ) {
+        dimensions { datetime }
+        count
+        sum { visits edgeResponseBytes }
+        avg { sampleInterval }
+      }
+    }
+  }
+}
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Account ID helper
+// ---------------------------------------------------------------------------
+
+function requireAccountId(client: CloudflareClient): string {
+  const accountId = client.getAccountId();
+  if (!accountId) {
+    throw new Error(
+      "CLOUDFLARE_ACCOUNT_ID environment variable is required for Web Analytics operations",
+    );
+  }
+  return accountId;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const webAnalyticsToolDefinitions = [
+  {
+    name: "cloudflare_web_analytics_list",
+    description:
+      "List all Web Analytics (RUM) sites for the account. Returns site IDs, hostnames, and creation dates.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        order_by: {
+          type: "string",
+          enum: ["host", "created"],
+          description: "Order results by field (default: host)",
+        },
+      },
+    },
+  },
+  {
+    name: "cloudflare_web_analytics_create",
+    description:
+      "Create/enable a Web Analytics (RUM) site. Enables privacy-first, cookie-free analytics beacon auto-injection for the specified hostname.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        host: {
+          type: "string",
+          description: "Hostname to enable analytics on (e.g., 'example.com')",
+        },
+        zone_tag: {
+          type: "string",
+          description:
+            "Optional zone ID to link the site to (enables auto-inject at the edge). 32-char hex.",
+        },
+        auto_install: {
+          type: "boolean",
+          description: "Auto-inject the beacon script at the edge (default: true)",
+        },
+      },
+      required: ["host"],
+    },
+  },
+  {
+    name: "cloudflare_web_analytics_get",
+    description: "Get details of a specific Web Analytics (RUM) site by ID.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        site_id: {
+          type: "string",
+          description: "RUM site ID",
+        },
+      },
+      required: ["site_id"],
+    },
+  },
+  {
+    name: "cloudflare_web_analytics_delete",
+    description: "Delete a Web Analytics (RUM) site and stop collecting analytics.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        site_id: {
+          type: "string",
+          description: "RUM site ID to delete",
+        },
+      },
+      required: ["site_id"],
+    },
+  },
+  {
+    name: "cloudflare_web_analytics_stats",
+    description:
+      "Query Web Analytics traffic stats for a zone. Returns page views, visits, and bandwidth grouped by time.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        zone_id: {
+          type: "string",
+          description:
+            "Zone ID (32-char hex) or zone name (e.g., 'example.com')",
+        },
+        since: {
+          type: "string",
+          description:
+            "ISO 8601 datetime to query from (default: 24 hours ago). E.g., '2026-03-15T00:00:00Z'",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of data points to return (default: 100, max: 10000)",
+        },
+      },
+      required: ["zone_id"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleWebAnalyticsTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: CloudflareClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "cloudflare_web_analytics_list": {
+        const parsed = WebAnalyticsListSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const params: Record<string, unknown> = {};
+        if (parsed.order_by) params.order_by = parsed.order_by;
+        const result = await client.get<unknown>(
+          `/accounts/${accountId}/rum/site_info/list`,
+          params,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_web_analytics_create": {
+        const parsed = WebAnalyticsCreateSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const body: Record<string, unknown> = {
+          host: parsed.host,
+          auto_install: parsed.auto_install ?? true,
+        };
+        if (parsed.zone_tag) body.zone_tag = parsed.zone_tag;
+        const result = await client.post<unknown>(
+          `/accounts/${accountId}/rum/site_info`,
+          body,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_web_analytics_get": {
+        const parsed = WebAnalyticsGetSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.get<unknown>(
+          `/accounts/${accountId}/rum/site_info/${parsed.site_id}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_web_analytics_delete": {
+        const parsed = WebAnalyticsDeleteSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.delete<unknown>(
+          `/accounts/${accountId}/rum/site_info/${parsed.site_id}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_web_analytics_stats": {
+        const parsed = WebAnalyticsStatsSchema.parse(args);
+        const zoneId = await client.resolveZoneId(parsed.zone_id);
+        const since =
+          parsed.since ?? new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+        const limit = parsed.limit ?? 100;
+        const result = await client.graphql<unknown>(WEB_ANALYTICS_STATS_QUERY, {
+          zoneTag: zoneId,
+          since,
+          limit,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown Web Analytics tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/tests/tools/web-analytics.test.ts
+++ b/tests/tools/web-analytics.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi } from 'vitest';
+import { webAnalyticsToolDefinitions, handleWebAnalyticsTool } from '../../src/tools/web-analytics.js';
+import type { CloudflareClient } from '../../src/client/cloudflare-client.js';
+
+const ACCOUNT_ID = '00000000000000000000000000000001';
+
+function mockClient(overrides: Partial<CloudflareClient> = {}): CloudflareClient {
+  return {
+    get: vi.fn().mockResolvedValue([]),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    resolveZoneId: vi.fn().mockResolvedValue('00000000000000000000000000000002'),
+    getRaw: vi.fn().mockResolvedValue(''),
+    getWithHeaders: vi.fn().mockResolvedValue({ result: [], headers: {} }),
+    postForm: vi.fn().mockResolvedValue({}),
+    putForm: vi.fn().mockResolvedValue({}),
+    putRaw: vi.fn().mockResolvedValue(undefined),
+    graphql: vi.fn().mockResolvedValue({
+      viewer: {
+        zones: [{
+          httpRequestsAdaptiveGroups: [
+            {
+              dimensions: { datetime: '2026-03-15T00:00:00Z' },
+              count: 500,
+              sum: { visits: 200, edgeResponseBytes: 1048576 },
+              avg: { sampleInterval: 1 },
+            },
+          ],
+        }],
+      },
+    }),
+    getAccountId: vi.fn().mockReturnValue(ACCOUNT_ID),
+    ...overrides,
+  } as unknown as CloudflareClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+describe('Web Analytics Tool Definitions', () => {
+  it('exports 5 tool definitions', () => {
+    expect(webAnalyticsToolDefinitions).toHaveLength(5);
+  });
+
+  it('all tools have cloudflare_web_analytics_ prefix', () => {
+    for (const tool of webAnalyticsToolDefinitions) {
+      expect(tool.name).toMatch(/^cloudflare_web_analytics_/);
+    }
+  });
+
+  it('all tools have non-empty descriptions', () => {
+    for (const tool of webAnalyticsToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('all tools have inputSchema with type object', () => {
+    for (const tool of webAnalyticsToolDefinitions) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleWebAnalyticsTool
+// ---------------------------------------------------------------------------
+
+describe('handleWebAnalyticsTool', () => {
+  describe('cloudflare_web_analytics_list', () => {
+    it('lists RUM sites', async () => {
+      const client = mockClient();
+
+      const result = await handleWebAnalyticsTool('cloudflare_web_analytics_list', {}, client);
+
+      expect(result.content[0].type).toBe('text');
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/rum/site_info/list`,
+        {},
+      );
+    });
+
+    it('passes order_by parameter', async () => {
+      const client = mockClient();
+
+      await handleWebAnalyticsTool('cloudflare_web_analytics_list', { order_by: 'created' }, client);
+
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/rum/site_info/list`,
+        { order_by: 'created' },
+      );
+    });
+
+    it('returns error when account_id is missing', async () => {
+      const client = mockClient({ getAccountId: vi.fn().mockReturnValue(undefined) });
+
+      const result = await handleWebAnalyticsTool('cloudflare_web_analytics_list', {}, client);
+
+      expect(result.content[0].text).toContain('CLOUDFLARE_ACCOUNT_ID');
+    });
+  });
+
+  describe('cloudflare_web_analytics_create', () => {
+    it('creates a RUM site with host', async () => {
+      const client = mockClient();
+
+      await handleWebAnalyticsTool('cloudflare_web_analytics_create', { host: 'example.com' }, client);
+
+      expect(client.post).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/rum/site_info`,
+        { host: 'example.com', auto_install: true },
+      );
+    });
+
+    it('passes zone_tag and auto_install', async () => {
+      const client = mockClient();
+
+      await handleWebAnalyticsTool(
+        'cloudflare_web_analytics_create',
+        { host: 'example.com', zone_tag: '00000000000000000000000000000003', auto_install: false },
+        client,
+      );
+
+      expect(client.post).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/rum/site_info`,
+        { host: 'example.com', auto_install: false, zone_tag: '00000000000000000000000000000003' },
+      );
+    });
+
+    it('rejects missing host', async () => {
+      const client = mockClient();
+
+      const result = await handleWebAnalyticsTool('cloudflare_web_analytics_create', {}, client);
+
+      expect(result.content[0].text).toContain('Error');
+    });
+  });
+
+  describe('cloudflare_web_analytics_get', () => {
+    it('gets a RUM site by ID', async () => {
+      const client = mockClient();
+
+      await handleWebAnalyticsTool('cloudflare_web_analytics_get', { site_id: 'site-123' }, client);
+
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/rum/site_info/site-123`,
+      );
+    });
+
+    it('rejects missing site_id', async () => {
+      const client = mockClient();
+
+      const result = await handleWebAnalyticsTool('cloudflare_web_analytics_get', {}, client);
+
+      expect(result.content[0].text).toContain('Error');
+    });
+  });
+
+  describe('cloudflare_web_analytics_delete', () => {
+    it('deletes a RUM site by ID', async () => {
+      const client = mockClient();
+
+      await handleWebAnalyticsTool('cloudflare_web_analytics_delete', { site_id: 'site-123' }, client);
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/rum/site_info/site-123`,
+      );
+    });
+  });
+
+  describe('cloudflare_web_analytics_stats', () => {
+    it('queries stats via GraphQL', async () => {
+      const client = mockClient();
+
+      const result = await handleWebAnalyticsTool(
+        'cloudflare_web_analytics_stats',
+        { zone_id: '00000000000000000000000000000002' },
+        client,
+      );
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('httpRequestsAdaptiveGroups');
+      expect(client.resolveZoneId).toHaveBeenCalledWith('00000000000000000000000000000002');
+      expect(client.graphql).toHaveBeenCalledWith(
+        expect.stringContaining('httpRequestsAdaptiveGroups'),
+        expect.objectContaining({
+          zoneTag: '00000000000000000000000000000002',
+          since: expect.any(String),
+          limit: 100,
+        }),
+      );
+    });
+
+    it('passes custom since and limit', async () => {
+      const client = mockClient();
+
+      await handleWebAnalyticsTool(
+        'cloudflare_web_analytics_stats',
+        { zone_id: '00000000000000000000000000000002', since: '2026-03-14T00:00:00Z', limit: 50 },
+        client,
+      );
+
+      expect(client.graphql).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          since: '2026-03-14T00:00:00Z',
+          limit: 50,
+        }),
+      );
+    });
+
+    it('rejects missing zone_id', async () => {
+      const client = mockClient();
+
+      const result = await handleWebAnalyticsTool('cloudflare_web_analytics_stats', {}, client);
+
+      expect(result.content[0].text).toContain('Error');
+    });
+  });
+
+  describe('unknown tool', () => {
+    it('returns unknown tool message', async () => {
+      const client = mockClient();
+
+      const result = await handleWebAnalyticsTool('cloudflare_web_analytics_unknown', {}, client);
+
+      expect(result.content[0].text).toContain('Unknown Web Analytics tool');
+    });
+  });
+
+  describe('API error handling', () => {
+    it('returns error message when API call fails', async () => {
+      const client = mockClient({
+        get: vi.fn().mockRejectedValue(new Error('API error')),
+      });
+
+      const result = await handleWebAnalyticsTool('cloudflare_web_analytics_list', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_web_analytics_list');
+      expect(result.content[0].text).toContain('API error');
+    });
+
+    it('returns error message when GraphQL call fails', async () => {
+      const client = mockClient({
+        graphql: vi.fn().mockRejectedValue(new Error('GraphQL error')),
+      });
+
+      const result = await handleWebAnalyticsTool(
+        'cloudflare_web_analytics_stats',
+        { zone_id: '00000000000000000000000000000002' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_web_analytics_stats');
+      expect(result.content[0].text).toContain('GraphQL error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 5 Web Analytics (RUM) tools: `cloudflare_web_analytics_list`, `cloudflare_web_analytics_create`, `cloudflare_web_analytics_get`, `cloudflare_web_analytics_delete`, `cloudflare_web_analytics_stats`
- CRUD via REST API (`/accounts/{id}/rum/site_info`), stats via GraphQL (`httpRequestsAdaptiveGroups`)
- 19 unit tests covering all tools, validation errors, and API error handling

Closes #41

## Test plan
- [x] `npm run build` — compiles without errors
- [x] `npm test` — 19/19 web-analytics tests pass (240/242 total, 2 pre-existing dns_search failures)
- [ ] Live test after MCP restart: enable Web Analytics on a zone

🤖 Generated with [Claude Code](https://claude.com/claude-code)