### PR TITLE
feat: add R2 storage management tools

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -20,6 +20,7 @@ Claude Code skills compose multiple MCP tools into higher-level workflows. Skill
 | cloudflare-zero-trust | Auto | — | Zero Trust — access apps, policies, identity providers, gateway |
 | cloudflare-kv-manage | Auto | — | Workers KV — namespace and key-value CRUD operations |
 | cloudflare-worker-deploy | Auto | — | Workers — script deployment, routes, secrets, analytics |
+| cloudflare-r2-manage | Auto | — | R2 Storage — bucket and object management, audit workflows |
 
 ---
 
@@ -204,3 +205,21 @@ Claude Code skills compose multiple MCP tools into higher-level workflows. Skill
 - `cloudflare_worker_usage` — Per-script aggregated usage
 
 **Triggers:** User asks to deploy workers, manage worker routes or secrets, or view worker analytics.
+
+---
+
+### cloudflare-r2-manage
+
+**Type:** Auto-invocable
+**Description:** Manages Cloudflare R2 object storage buckets and objects. Covers creating buckets with location hints, listing objects with prefix filtering, inspecting object metadata, and deleting buckets and objects. Includes audit workflow for bucket inventory.
+
+**Tools used:**
+- `cloudflare_r2_bucket_list` — List all R2 buckets with optional name filter
+- `cloudflare_r2_bucket_create` — Create a new bucket with optional location hint
+- `cloudflare_r2_bucket_get` — Get bucket details (creation date, location)
+- `cloudflare_r2_bucket_delete` — Delete an empty bucket (destructive)
+- `cloudflare_r2_object_list` — List objects with prefix/delimiter filtering
+- `cloudflare_r2_object_get` — Get object metadata (size, type, etag)
+- `cloudflare_r2_object_delete` — Delete an object from a bucket
+
+**Triggers:** User asks to manage R2 buckets, list objects, or audit R2 storage.

--- a/.claude/skills/cloudflare-r2-manage/SKILL.md
+++ b/.claude/skills/cloudflare-r2-manage/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: cloudflare-r2-manage
+description: Manage Cloudflare R2 storage buckets and objects — create, list, inspect, delete buckets and objects
+---
+
+# Cloudflare R2 Storage Management
+
+Manage R2 object storage buckets and objects using Cloudflare API.
+
+## Prerequisites
+
+- `CLOUDFLARE_API_TOKEN` with R2 Storage permissions (read + write)
+- `CLOUDFLARE_ACCOUNT_ID` set (required for all R2 operations)
+
+## Workflows
+
+### List all buckets
+1. Call `cloudflare_r2_bucket_list` to see all R2 buckets in the account
+2. Use `name_contains` to filter by name substring
+
+### Create a bucket
+1. Call `cloudflare_r2_bucket_create` with a name (3-63 chars, lowercase alphanumeric + hyphens)
+2. Optionally specify `location_hint` for geographic placement:
+   - `weur` — Western Europe
+   - `eeur` — Eastern Europe
+   - `enam` — Eastern North America
+   - `wnam` — Western North America
+   - `apac` — Asia Pacific
+3. Follow naming convention: `assets-<zone-slug>` (prod) or `assets-uat-<zone-slug>` (UAT)
+
+### Get bucket details
+1. Call `cloudflare_r2_bucket_get` with `bucket_name`
+2. Returns creation date, location, and configuration
+
+### List objects in a bucket
+1. Call `cloudflare_r2_object_list` with `bucket_name`
+2. Use `prefix` to filter by path (e.g., `brand/` for brand assets)
+3. Use `delimiter` with `/` for directory-like listing
+4. Use `cursor` for pagination through large object sets
+
+### Get object metadata
+1. Call `cloudflare_r2_object_get` with `bucket_name` and `object_key`
+2. Returns size, etag, content type, last modified — does NOT return object body
+
+### Delete an object
+1. Call `cloudflare_r2_object_delete` with `bucket_name` and `object_key`
+2. Confirm before deleting — operation is not reversible
+
+### Delete a bucket (DESTRUCTIVE)
+1. **WARNING:** Bucket must be empty before deletion
+2. List objects first to verify the bucket is empty
+3. Call `cloudflare_r2_bucket_delete` with `bucket_name`
+4. Always ask for user confirmation before executing
+
+### R2 Bucket Audit
+1. Call `cloudflare_r2_bucket_list` to get all buckets
+2. For each bucket, call `cloudflare_r2_bucket_get` for details
+3. For each bucket, call `cloudflare_r2_object_list` with `delimiter: "/"` for top-level overview
+4. Report: bucket count, per-bucket object summary, naming convention compliance
+
+## Tools Used
+
+- `cloudflare_r2_bucket_list` — List all R2 buckets with optional name filter
+- `cloudflare_r2_bucket_create` — Create a new bucket with optional location hint
+- `cloudflare_r2_bucket_get` — Get bucket details (creation date, location)
+- `cloudflare_r2_bucket_delete` — Delete an empty bucket (destructive)
+- `cloudflare_r2_object_list` — List objects with prefix/delimiter filtering
+- `cloudflare_r2_object_get` — Get object metadata (size, type, etag)
+- `cloudflare_r2_object_delete` — Delete an object from a bucket
+
+## Naming Convention (ADR-0035)
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Public prod assets | `assets-<zone-slug>` | `assets-itunified-de` |
+| Public UAT assets | `assets-uat-<zone-slug>` | `assets-uat-itunified-de` |
+| Private internal | `internal-<purpose>` | `internal-backups` |
+
+## Rules
+
+- Always list buckets first if the user hasn't specified one
+- Confirm before any delete operation (object or bucket)
+- Bucket deletion requires the bucket to be empty first — list objects to verify
+- Bucket names: 3-63 chars, lowercase alphanumeric and hyphens, no leading/trailing hyphens
+- Object keys are limited to 1024 characters
+- For binary file uploads (images, etc.), use `wrangler r2 object put` or the Cloudflare dashboard
+- Follow ADR-0035 naming conventions for zone asset buckets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.16.7
+
+- **Add R2 storage management tools** (#43)
+  - 7 new tools: `cloudflare_r2_bucket_list`, `cloudflare_r2_bucket_create`, `cloudflare_r2_bucket_get`, `cloudflare_r2_bucket_delete`, `cloudflare_r2_object_list`, `cloudflare_r2_object_get`, `cloudflare_r2_object_delete`
+  - Bucket CRUD via REST API (`/accounts/{id}/r2/buckets`)
+  - Object listing and metadata via REST API (`/accounts/{id}/r2/buckets/{name}/objects`)
+  - Zod validation schemas: `R2BucketNameSchema`, `R2ObjectKeySchema`, `R2LocationHintSchema`
+  - 24 unit tests covering all tools, validation errors, and API error handling
+  - New skill: `cloudflare-r2-manage` — R2 bucket and object management workflows
+
 ## v2026.03.16.6
 
 - **Add Web Analytics (RUM) tools** (#41)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ src/
     waf.ts                   # WAF ruleset and custom rule tools
     zerotrust.ts             # Zero Trust Access and Gateway tools
     security.ts              # Security events, IP access rules, DDoS tools
+    r2.ts                    # R2 bucket and object management tools
   utils/
     validation.ts            # Shared Zod schemas (zone IDs, record types, etc.)
     errors.ts                # Cloudflare error extraction and CloudflareApiError

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Slim Cloudflare MCP Server for managing DNS, zones, tunnels, WAF, Zero Trust, an
 
 ## Features
 
-60 tools across 10 domains:
+67 tools across 11 domains:
 
 - **DNS** — Record management (A, AAAA, CNAME, MX, TXT, SRV, CAA, NS), batch operations
 - **Zones** — Zone listing, settings, SSL/TLS configuration, cache management
@@ -37,6 +37,7 @@ Slim Cloudflare MCP Server for managing DNS, zones, tunnels, WAF, Zero Trust, an
 - **Workers** — Script deployment, route management
 - **Worker Secrets** — Secret management (names only, values never exposed)
 - **Worker Analytics** — Invocation metrics, CPU time, error rates via GraphQL
+- **R2 Storage** — Bucket management, object listing and metadata, location hints
 
 ## Quick Start
 
@@ -86,6 +87,7 @@ Create an API Token at `dash.cloudflare.com/profile/api-tokens` with the followi
 - **Security events**: Zone > Analytics > Read
 - **Workers KV**: Account > Workers KV Storage > Edit
 - **Workers**: Account > Worker Scripts > Edit
+- **R2**: Account > R2 Storage > Edit
 
 ## Multi-Zone Support
 
@@ -116,6 +118,7 @@ Claude Code skills compose MCP tools into higher-level workflows. See [`.claude/
 | cloudflare-zero-trust | — | Zero Trust — access apps, policies, identity providers, gateway |
 | cloudflare-kv-manage | — | Workers KV — namespace and key-value CRUD operations |
 | cloudflare-worker-deploy | — | Workers — script deployment, routes, secrets, analytics |
+| cloudflare-r2-manage | — | R2 Storage — bucket and object management, audit workflows |
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { workersToolDefinitions, handleWorkersTool } from './tools/workers.js';
 import { workerSecretsToolDefinitions, handleWorkerSecretsTool } from './tools/worker-secrets.js';
 import { workerAnalyticsToolDefinitions, handleWorkerAnalyticsTool } from './tools/worker-analytics.js';
 import { webAnalyticsToolDefinitions, handleWebAnalyticsTool } from './tools/web-analytics.js';
+import { r2ToolDefinitions, handleR2Tool } from './tools/r2.js';
 
 const allToolDefinitions: Tool[] = ([
   ...zonesToolDefinitions,
@@ -32,6 +33,7 @@ const allToolDefinitions: Tool[] = ([
   ...workerSecretsToolDefinitions,
   ...workerAnalyticsToolDefinitions,
   ...webAnalyticsToolDefinitions,
+  ...r2ToolDefinitions,
 ] as unknown) as Tool[];
 
 const toolHandlers = new Map<
@@ -51,9 +53,10 @@ for (const def of workersToolDefinitions) toolHandlers.set(def.name, handleWorke
 for (const def of workerSecretsToolDefinitions) toolHandlers.set(def.name, handleWorkerSecretsTool);
 for (const def of workerAnalyticsToolDefinitions) toolHandlers.set(def.name, handleWorkerAnalyticsTool);
 for (const def of webAnalyticsToolDefinitions) toolHandlers.set(def.name, handleWebAnalyticsTool);
+for (const def of r2ToolDefinitions) toolHandlers.set(def.name, handleR2Tool);
 
 const server = new Server(
-  { name: 'mcp-cloudflare', version: '2026.3.16.6' },
+  { name: 'mcp-cloudflare', version: '2026.3.16.7' },
   { capabilities: { tools: {} } }
 );
 

--- a/src/tools/r2.ts
+++ b/src/tools/r2.ts
@@ -1,0 +1,261 @@
+import { z } from "zod";
+import type { CloudflareClient } from "../client/cloudflare-client.js";
+import { R2BucketNameSchema, R2ObjectKeySchema, R2LocationHintSchema } from "../utils/validation.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const R2BucketListSchema = z.object({
+  name_contains: z.string().optional(),
+  cursor: z.string().optional(),
+  per_page: z.number().int().min(1).max(1000).optional(),
+  direction: z.enum(["asc", "desc"]).optional(),
+  order: z.enum(["name"]).optional(),
+});
+
+const R2BucketCreateSchema = z.object({
+  name: R2BucketNameSchema,
+  location_hint: R2LocationHintSchema.optional(),
+});
+
+const R2BucketGetSchema = z.object({
+  bucket_name: R2BucketNameSchema,
+});
+
+const R2BucketDeleteSchema = z.object({
+  bucket_name: R2BucketNameSchema,
+});
+
+const R2ObjectListSchema = z.object({
+  bucket_name: R2BucketNameSchema,
+  prefix: z.string().optional(),
+  delimiter: z.string().optional(),
+  cursor: z.string().optional(),
+  per_page: z.number().int().min(1).max(1000).optional(),
+});
+
+const R2ObjectGetSchema = z.object({
+  bucket_name: R2BucketNameSchema,
+  object_key: R2ObjectKeySchema,
+});
+
+const R2ObjectDeleteSchema = z.object({
+  bucket_name: R2BucketNameSchema,
+  object_key: R2ObjectKeySchema,
+});
+
+// ---------------------------------------------------------------------------
+// Account ID helper
+// ---------------------------------------------------------------------------
+
+function requireAccountId(client: CloudflareClient): string {
+  const accountId = client.getAccountId();
+  if (!accountId) {
+    throw new Error(
+      "CLOUDFLARE_ACCOUNT_ID environment variable is required for R2 operations",
+    );
+  }
+  return accountId;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const r2ToolDefinitions = [
+  {
+    name: "cloudflare_r2_bucket_list",
+    description: "List all R2 buckets in the account. Supports filtering by name and pagination.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name_contains: { type: "string", description: "Filter buckets whose name contains this string" },
+        cursor: { type: "string", description: "Pagination cursor from a previous request" },
+        per_page: { type: "number", description: "Results per page (1-1000, default: 1000)" },
+        direction: { type: "string", enum: ["asc", "desc"], description: "Sort direction (default: asc)" },
+        order: { type: "string", enum: ["name"], description: "Sort field" },
+      },
+    },
+  },
+  {
+    name: "cloudflare_r2_bucket_create",
+    description: "Create a new R2 storage bucket. Name must be 3-63 lowercase alphanumeric characters with hyphens.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: { type: "string", description: "Bucket name (3-63 chars, lowercase alphanumeric and hyphens)" },
+        location_hint: {
+          type: "string",
+          enum: ["apac", "eeur", "enam", "weur", "wnam"],
+          description: "Location hint for bucket placement (apac=Asia Pacific, eeur=Eastern Europe, enam=Eastern North America, weur=Western Europe, wnam=Western North America)",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "cloudflare_r2_bucket_get",
+    description: "Get details of an R2 bucket including creation date and location.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        bucket_name: { type: "string", description: "Name of the R2 bucket" },
+      },
+      required: ["bucket_name"],
+    },
+  },
+  {
+    name: "cloudflare_r2_bucket_delete",
+    description: "DESTRUCTIVE: Delete an R2 bucket. The bucket must be empty before deletion.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        bucket_name: { type: "string", description: "Name of the R2 bucket to delete" },
+      },
+      required: ["bucket_name"],
+    },
+  },
+  {
+    name: "cloudflare_r2_object_list",
+    description: "List objects in an R2 bucket. Supports prefix filtering, delimiter for directory-like listing, and pagination.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        bucket_name: { type: "string", description: "Name of the R2 bucket" },
+        prefix: { type: "string", description: "Filter objects by key prefix (e.g., 'brand/' to list only brand assets)" },
+        delimiter: { type: "string", description: "Delimiter for directory-like listing (e.g., '/' to group by folder)" },
+        cursor: { type: "string", description: "Pagination cursor from a previous request" },
+        per_page: { type: "number", description: "Maximum objects to return (1-1000)" },
+      },
+      required: ["bucket_name"],
+    },
+  },
+  {
+    name: "cloudflare_r2_object_get",
+    description: "Get metadata of an object in an R2 bucket (size, etag, content type, last modified). Does not return object body.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        bucket_name: { type: "string", description: "Name of the R2 bucket" },
+        object_key: { type: "string", description: "Key (path) of the object" },
+      },
+      required: ["bucket_name", "object_key"],
+    },
+  },
+  {
+    name: "cloudflare_r2_object_delete",
+    description: "Delete an object from an R2 bucket.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        bucket_name: { type: "string", description: "Name of the R2 bucket" },
+        object_key: { type: "string", description: "Key (path) of the object to delete" },
+      },
+      required: ["bucket_name", "object_key"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleR2Tool(
+  name: string,
+  args: Record<string, unknown>,
+  client: CloudflareClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "cloudflare_r2_bucket_list": {
+        const parsed = R2BucketListSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const params: Record<string, unknown> = {};
+        if (parsed.name_contains !== undefined) params["name_contains"] = parsed.name_contains;
+        if (parsed.cursor !== undefined) params["cursor"] = parsed.cursor;
+        if (parsed.per_page !== undefined) params["per_page"] = parsed.per_page;
+        if (parsed.direction !== undefined) params["direction"] = parsed.direction;
+        if (parsed.order !== undefined) params["order"] = parsed.order;
+        const result = await client.get(
+          `/accounts/${accountId}/r2/buckets`,
+          params,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_r2_bucket_create": {
+        const parsed = R2BucketCreateSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const body: Record<string, unknown> = { name: parsed.name };
+        if (parsed.location_hint !== undefined) body["locationHint"] = parsed.location_hint;
+        const result = await client.post(
+          `/accounts/${accountId}/r2/buckets`,
+          body,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_r2_bucket_get": {
+        const parsed = R2BucketGetSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.get(
+          `/accounts/${accountId}/r2/buckets/${parsed.bucket_name}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_r2_bucket_delete": {
+        const parsed = R2BucketDeleteSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.delete(
+          `/accounts/${accountId}/r2/buckets/${parsed.bucket_name}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_r2_object_list": {
+        const parsed = R2ObjectListSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const params: Record<string, unknown> = {};
+        if (parsed.prefix !== undefined) params["prefix"] = parsed.prefix;
+        if (parsed.delimiter !== undefined) params["delimiter"] = parsed.delimiter;
+        if (parsed.cursor !== undefined) params["cursor"] = parsed.cursor;
+        if (parsed.per_page !== undefined) params["per_page"] = parsed.per_page;
+        const result = await client.get(
+          `/accounts/${accountId}/r2/buckets/${parsed.bucket_name}/objects`,
+          params,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_r2_object_get": {
+        const parsed = R2ObjectGetSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.get(
+          `/accounts/${accountId}/r2/buckets/${parsed.bucket_name}/objects/${parsed.object_key}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_r2_object_delete": {
+        const parsed = R2ObjectDeleteSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.delete(
+          `/accounts/${accountId}/r2/buckets/${parsed.bucket_name}/objects/${parsed.object_key}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown R2 tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -116,3 +116,28 @@ export const KvKeySchema = z
   .string()
   .min(1, "KV key is required")
   .max(512, "KV key must be 512 characters or less");
+
+/** R2 bucket name — 3-63 chars, lowercase alphanumeric and hyphens */
+export const R2BucketNameSchema = z
+  .string()
+  .min(3, "Bucket name must be at least 3 characters")
+  .max(63, "Bucket name must be 63 characters or less")
+  .regex(
+    /^[a-z0-9][a-z0-9-]*[a-z0-9]$/,
+    "Bucket name must be lowercase alphanumeric with hyphens, cannot start or end with hyphen",
+  );
+
+/** R2 object key — the path/name of an object in a bucket */
+export const R2ObjectKeySchema = z
+  .string()
+  .min(1, "Object key is required")
+  .max(1024, "Object key must be 1024 characters or less");
+
+/** R2 location hint for bucket creation */
+export const R2LocationHintSchema = z.enum([
+  "apac",
+  "eeur",
+  "enam",
+  "weur",
+  "wnam",
+]);

--- a/tests/tools/r2.test.ts
+++ b/tests/tools/r2.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, vi } from 'vitest';
+import { r2ToolDefinitions, handleR2Tool } from '../../src/tools/r2.js';
+import type { CloudflareClient } from '../../src/client/cloudflare-client.js';
+
+const ACCOUNT_ID = '00000000000000000000000000000001';
+
+function mockClient(overrides: Partial<CloudflareClient> = {}): CloudflareClient {
+  return {
+    get: vi.fn().mockResolvedValue([]),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    resolveZoneId: vi.fn().mockResolvedValue('00000000000000000000000000000002'),
+    getRaw: vi.fn().mockResolvedValue(''),
+    getWithHeaders: vi.fn().mockResolvedValue({ result: [], headers: {} }),
+    postForm: vi.fn().mockResolvedValue({}),
+    putForm: vi.fn().mockResolvedValue({}),
+    putRaw: vi.fn().mockResolvedValue(undefined),
+    graphql: vi.fn().mockResolvedValue({}),
+    getAccountId: vi.fn().mockReturnValue(ACCOUNT_ID),
+    ...overrides,
+  } as unknown as CloudflareClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+describe('R2 Tool Definitions', () => {
+  it('exports 7 tool definitions', () => {
+    expect(r2ToolDefinitions).toHaveLength(7);
+  });
+
+  it('all tools have cloudflare_r2_ prefix', () => {
+    for (const tool of r2ToolDefinitions) {
+      expect(tool.name).toMatch(/^cloudflare_r2_/);
+    }
+  });
+
+  it('all tools have non-empty descriptions', () => {
+    for (const tool of r2ToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('all tools have inputSchema with type object', () => {
+    for (const tool of r2ToolDefinitions) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleR2Tool — Bucket operations
+// ---------------------------------------------------------------------------
+
+describe('handleR2Tool', () => {
+  describe('cloudflare_r2_bucket_list', () => {
+    it('lists buckets with no filters', async () => {
+      const mockBuckets = {
+        buckets: [
+          { name: 'assets-itunified-de', creation_date: '2026-03-16T00:00:00Z' },
+          { name: 'assets-itunified-io', creation_date: '2026-03-16T00:00:00Z' },
+        ],
+      };
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockBuckets) });
+
+      const result = await handleR2Tool('cloudflare_r2_bucket_list', {}, client);
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('assets-itunified-de');
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets`,
+        {},
+      );
+    });
+
+    it('passes filter and pagination params', async () => {
+      const client = mockClient({ get: vi.fn().mockResolvedValue({ buckets: [] }) });
+
+      await handleR2Tool('cloudflare_r2_bucket_list', {
+        name_contains: 'assets',
+        per_page: 50,
+        direction: 'desc',
+        order: 'name',
+      }, client);
+
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets`,
+        { name_contains: 'assets', per_page: 50, direction: 'desc', order: 'name' },
+      );
+    });
+
+    it('returns error when account_id is missing', async () => {
+      const client = mockClient({ getAccountId: vi.fn().mockReturnValue(undefined) });
+
+      const result = await handleR2Tool('cloudflare_r2_bucket_list', {}, client);
+
+      expect(result.content[0].text).toContain('CLOUDFLARE_ACCOUNT_ID');
+    });
+  });
+
+  describe('cloudflare_r2_bucket_create', () => {
+    it('creates a bucket with name only', async () => {
+      const mockBucket = { name: 'assets-itunified-de', creation_date: '2026-03-16T00:00:00Z' };
+      const client = mockClient({ post: vi.fn().mockResolvedValue(mockBucket) });
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_bucket_create',
+        { name: 'assets-itunified-de' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('assets-itunified-de');
+      expect(client.post).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets`,
+        { name: 'assets-itunified-de' },
+      );
+    });
+
+    it('creates a bucket with location hint', async () => {
+      const client = mockClient({ post: vi.fn().mockResolvedValue({ name: 'my-bucket' }) });
+
+      await handleR2Tool(
+        'cloudflare_r2_bucket_create',
+        { name: 'my-bucket', location_hint: 'weur' },
+        client,
+      );
+
+      expect(client.post).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets`,
+        { name: 'my-bucket', locationHint: 'weur' },
+      );
+    });
+
+    it('requires name parameter', async () => {
+      const client = mockClient();
+
+      const result = await handleR2Tool('cloudflare_r2_bucket_create', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_r2_bucket_create');
+    });
+
+    it('rejects invalid bucket name (too short)', async () => {
+      const client = mockClient();
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_bucket_create',
+        { name: 'ab' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_r2_bucket_create');
+    });
+
+    it('rejects bucket name starting with hyphen', async () => {
+      const client = mockClient();
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_bucket_create',
+        { name: '-invalid-name' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_r2_bucket_create');
+    });
+
+    it('rejects invalid location hint', async () => {
+      const client = mockClient();
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_bucket_create',
+        { name: 'valid-bucket', location_hint: 'invalid' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_r2_bucket_create');
+    });
+  });
+
+  describe('cloudflare_r2_bucket_get', () => {
+    it('gets bucket details', async () => {
+      const mockBucket = {
+        name: 'assets-itunified-de',
+        creation_date: '2026-03-16T00:00:00Z',
+        location: 'WEUR',
+      };
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockBucket) });
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_bucket_get',
+        { bucket_name: 'assets-itunified-de' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('assets-itunified-de');
+      expect(result.content[0].text).toContain('WEUR');
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets/assets-itunified-de`,
+      );
+    });
+  });
+
+  describe('cloudflare_r2_bucket_delete', () => {
+    it('deletes a bucket', async () => {
+      const client = mockClient({ delete: vi.fn().mockResolvedValue({}) });
+
+      await handleR2Tool(
+        'cloudflare_r2_bucket_delete',
+        { bucket_name: 'old-bucket' },
+        client,
+      );
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets/old-bucket`,
+      );
+    });
+
+    it('rejects invalid bucket name', async () => {
+      const client = mockClient();
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_bucket_delete',
+        { bucket_name: 'X' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_r2_bucket_delete');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Object operations
+  // ---------------------------------------------------------------------------
+
+  describe('cloudflare_r2_object_list', () => {
+    it('lists objects in a bucket', async () => {
+      const mockObjects = {
+        objects: [
+          { key: 'brand/logo.svg', size: 2048, last_modified: '2026-03-16T00:00:00Z' },
+          { key: 'hero/hero-main.jpg', size: 524288, last_modified: '2026-03-16T00:00:00Z' },
+        ],
+      };
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockObjects) });
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_object_list',
+        { bucket_name: 'assets-itunified-de' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('logo.svg');
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets/assets-itunified-de/objects`,
+        {},
+      );
+    });
+
+    it('passes prefix and delimiter filters', async () => {
+      const client = mockClient({ get: vi.fn().mockResolvedValue({ objects: [] }) });
+
+      await handleR2Tool(
+        'cloudflare_r2_object_list',
+        { bucket_name: 'assets-itunified-de', prefix: 'brand/', delimiter: '/', per_page: 100 },
+        client,
+      );
+
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets/assets-itunified-de/objects`,
+        { prefix: 'brand/', delimiter: '/', per_page: 100 },
+      );
+    });
+  });
+
+  describe('cloudflare_r2_object_get', () => {
+    it('gets object metadata', async () => {
+      const mockMeta = {
+        key: 'brand/logo.svg',
+        size: 2048,
+        etag: '"abc123"',
+        http_metadata: { content_type: 'image/svg+xml' },
+        last_modified: '2026-03-16T00:00:00Z',
+      };
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockMeta) });
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_object_get',
+        { bucket_name: 'assets-itunified-de', object_key: 'brand/logo.svg' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('logo.svg');
+      expect(result.content[0].text).toContain('image/svg+xml');
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets/assets-itunified-de/objects/brand/logo.svg`,
+      );
+    });
+
+    it('requires both bucket_name and object_key', async () => {
+      const client = mockClient();
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_object_get',
+        { bucket_name: 'assets-itunified-de' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_r2_object_get');
+    });
+  });
+
+  describe('cloudflare_r2_object_delete', () => {
+    it('deletes an object', async () => {
+      const client = mockClient({ delete: vi.fn().mockResolvedValue({}) });
+
+      await handleR2Tool(
+        'cloudflare_r2_object_delete',
+        { bucket_name: 'assets-itunified-de', object_key: 'old-file.txt' },
+        client,
+      );
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets/assets-itunified-de/objects/old-file.txt`,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge cases
+  // ---------------------------------------------------------------------------
+
+  describe('unknown tool', () => {
+    it('returns unknown tool message for unrecognized tool name', async () => {
+      const client = mockClient();
+
+      const result = await handleR2Tool('cloudflare_r2_unknown', {}, client);
+
+      expect(result.content[0].text).toContain('Unknown R2 tool');
+    });
+  });
+
+  describe('API error handling', () => {
+    it('returns error message when API call fails', async () => {
+      const client = mockClient({
+        get: vi.fn().mockRejectedValue(new Error('API request failed')),
+      });
+
+      const result = await handleR2Tool('cloudflare_r2_bucket_list', {}, client);
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_r2_bucket_list');
+      expect(result.content[0].text).toContain('API request failed');
+    });
+
+    it('handles non-Error thrown values', async () => {
+      const client = mockClient({
+        get: vi.fn().mockRejectedValue('string error'),
+      });
+
+      const result = await handleR2Tool('cloudflare_r2_bucket_list', {}, client);
+
+      expect(result.content[0].text).toContain('Unknown error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- 7 new R2 tools: bucket CRUD + object list/get/delete (#43)
- Zod validation schemas: `R2BucketNameSchema`, `R2ObjectKeySchema`, `R2LocationHintSchema`
- 24 unit tests covering all tools, validation errors, and API error handling
- New skill: `cloudflare-r2-manage` for bucket and object management workflows
- Updated README, CLAUDE.md, skills README, CHANGELOG

## Test plan

- [x] `npm run build` succeeds
- [x] 24 new R2 tests pass (`npx vitest run tests/tools/r2.test.ts`)
- [x] All existing tests unaffected (2 pre-existing dns_search failures unchanged)
- [ ] Live test after merge: `cloudflare_r2_bucket_list`

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)