### PR TITLE
feat: add R2 custom domain management tools

### DIFF
--- a/.claude/skills/cloudflare-r2-manage/SKILL.md
+++ b/.claude/skills/cloudflare-r2-manage/SKILL.md
@@ -52,6 +52,22 @@ Manage R2 object storage buckets and objects using Cloudflare API.
 3. Call `cloudflare_r2_bucket_delete` with `bucket_name`
 4. Always ask for user confirmation before executing
 
+### Enable public access via custom domain
+1. Call `cloudflare_r2_bucket_domain_add` with `bucket_name` and `domain`
+2. The domain must belong to a Cloudflare zone in the same account
+3. Cloudflare automatically creates a CNAME DNS record for the domain
+4. Bucket becomes publicly readable at `https://<domain>/`
+5. Writes still require API authentication — public = read-only
+
+### List custom domains on a bucket
+1. Call `cloudflare_r2_bucket_domain_list` with `bucket_name`
+2. Returns domain names, status (active/pending), and zone info
+
+### Remove a custom domain
+1. Call `cloudflare_r2_bucket_domain_remove` with `bucket_name` and `domain`
+2. This disables public access via that domain
+3. Confirm before removing — may break live websites referencing the domain
+
 ### R2 Bucket Audit
 1. Call `cloudflare_r2_bucket_list` to get all buckets
 2. For each bucket, call `cloudflare_r2_bucket_get` for details
@@ -67,6 +83,9 @@ Manage R2 object storage buckets and objects using Cloudflare API.
 - `cloudflare_r2_object_list` — List objects with prefix/delimiter filtering
 - `cloudflare_r2_object_get` — Get object metadata (size, type, etag)
 - `cloudflare_r2_object_delete` — Delete an object from a bucket
+- `cloudflare_r2_bucket_domain_list` — List custom domains attached to a bucket
+- `cloudflare_r2_bucket_domain_add` — Attach a custom domain (enables public read access)
+- `cloudflare_r2_bucket_domain_remove` — Remove a custom domain from a bucket
 
 ## Naming Convention (ADR-0035)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.16.8
+
+- **Add R2 custom domain management tools** (#45)
+  - 3 new tools: `cloudflare_r2_bucket_domain_list`, `cloudflare_r2_bucket_domain_add`, `cloudflare_r2_bucket_domain_remove`
+  - Attach/remove custom domains to R2 buckets for public access
+  - CF auto-creates CNAME DNS records when domains are attached
+  - 4 new unit tests (28 total R2 tests)
+  - R2 tools now total 10 (bucket CRUD + object ops + domain management)
+
 ## v2026.03.16.7
 
 - **Add R2 storage management tools** (#43)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Slim Cloudflare MCP Server for managing DNS, zones, tunnels, WAF, Zero Trust, an
 
 ## Features
 
-67 tools across 11 domains:
+70 tools across 11 domains:
 
 - **DNS** — Record management (A, AAAA, CNAME, MX, TXT, SRV, CAA, NS), batch operations
 - **Zones** — Zone listing, settings, SSL/TLS configuration, cache management
@@ -37,7 +37,7 @@ Slim Cloudflare MCP Server for managing DNS, zones, tunnels, WAF, Zero Trust, an
 - **Workers** — Script deployment, route management
 - **Worker Secrets** — Secret management (names only, values never exposed)
 - **Worker Analytics** — Invocation metrics, CPU time, error rates via GraphQL
-- **R2 Storage** — Bucket management, object listing and metadata, location hints
+- **R2 Storage** — Bucket management, object listing and metadata, custom domains, location hints
 
 ## Quick Start
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ for (const def of webAnalyticsToolDefinitions) toolHandlers.set(def.name, handle
 for (const def of r2ToolDefinitions) toolHandlers.set(def.name, handleR2Tool);
 
 const server = new Server(
-  { name: 'mcp-cloudflare', version: '2026.3.16.7' },
+  { name: 'mcp-cloudflare', version: '2026.3.16.8' },
   { capabilities: { tools: {} } }
 );
 

--- a/src/tools/r2.ts
+++ b/src/tools/r2.ts
@@ -45,6 +45,20 @@ const R2ObjectDeleteSchema = z.object({
   object_key: R2ObjectKeySchema,
 });
 
+const R2BucketDomainListSchema = z.object({
+  bucket_name: R2BucketNameSchema,
+});
+
+const R2BucketDomainAddSchema = z.object({
+  bucket_name: R2BucketNameSchema,
+  domain: z.string().min(1, "Domain is required"),
+});
+
+const R2BucketDomainRemoveSchema = z.object({
+  bucket_name: R2BucketNameSchema,
+  domain: z.string().min(1, "Domain is required"),
+});
+
 // ---------------------------------------------------------------------------
 // Account ID helper
 // ---------------------------------------------------------------------------
@@ -155,6 +169,41 @@ export const r2ToolDefinitions = [
       required: ["bucket_name", "object_key"],
     },
   },
+  {
+    name: "cloudflare_r2_bucket_domain_list",
+    description: "List custom domains attached to an R2 bucket. Shows domain name, status, and zone info.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        bucket_name: { type: "string", description: "Name of the R2 bucket" },
+      },
+      required: ["bucket_name"],
+    },
+  },
+  {
+    name: "cloudflare_r2_bucket_domain_add",
+    description: "Attach a custom domain to an R2 bucket, enabling public access via that domain. The domain must belong to a zone in the same account. Cloudflare automatically creates a CNAME record.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        bucket_name: { type: "string", description: "Name of the R2 bucket" },
+        domain: { type: "string", description: "Custom domain to attach (e.g., assets.example.com)" },
+      },
+      required: ["bucket_name", "domain"],
+    },
+  },
+  {
+    name: "cloudflare_r2_bucket_domain_remove",
+    description: "Remove a custom domain from an R2 bucket. This disables public access via that domain.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        bucket_name: { type: "string", description: "Name of the R2 bucket" },
+        domain: { type: "string", description: "Custom domain to remove" },
+      },
+      required: ["bucket_name", "domain"],
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -243,6 +292,34 @@ export async function handleR2Tool(
         const accountId = requireAccountId(client);
         const result = await client.delete(
           `/accounts/${accountId}/r2/buckets/${parsed.bucket_name}/objects/${parsed.object_key}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_r2_bucket_domain_list": {
+        const parsed = R2BucketDomainListSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.get(
+          `/accounts/${accountId}/r2/buckets/${parsed.bucket_name}/domains`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_r2_bucket_domain_add": {
+        const parsed = R2BucketDomainAddSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.put(
+          `/accounts/${accountId}/r2/buckets/${parsed.bucket_name}/domains`,
+          { domain: parsed.domain },
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "cloudflare_r2_bucket_domain_remove": {
+        const parsed = R2BucketDomainRemoveSchema.parse(args);
+        const accountId = requireAccountId(client);
+        const result = await client.delete(
+          `/accounts/${accountId}/r2/buckets/${parsed.bucket_name}/domains/${parsed.domain}`,
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }

--- a/tests/tools/r2.test.ts
+++ b/tests/tools/r2.test.ts
@@ -28,8 +28,8 @@ function mockClient(overrides: Partial<CloudflareClient> = {}): CloudflareClient
 // ---------------------------------------------------------------------------
 
 describe('R2 Tool Definitions', () => {
-  it('exports 7 tool definitions', () => {
-    expect(r2ToolDefinitions).toHaveLength(7);
+  it('exports 10 tool definitions', () => {
+    expect(r2ToolDefinitions).toHaveLength(10);
   });
 
   it('all tools have cloudflare_r2_ prefix', () => {
@@ -324,6 +324,79 @@ describe('handleR2Tool', () => {
 
       expect(client.delete).toHaveBeenCalledWith(
         `/accounts/${ACCOUNT_ID}/r2/buckets/assets-itunified-de/objects/old-file.txt`,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Custom domain operations
+  // ---------------------------------------------------------------------------
+
+  describe('cloudflare_r2_bucket_domain_list', () => {
+    it('lists custom domains for a bucket', async () => {
+      const mockDomains = {
+        domains: [
+          { domain: 'assets.example.com', zone_id: '00000000000000000000000000000002', status: 'active' },
+        ],
+      };
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockDomains) });
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_bucket_domain_list',
+        { bucket_name: 'assets-itunified-de' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('assets.example.com');
+      expect(client.get).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets/assets-itunified-de/domains`,
+      );
+    });
+  });
+
+  describe('cloudflare_r2_bucket_domain_add', () => {
+    it('attaches a custom domain to a bucket', async () => {
+      const mockResult = { domain: 'assets.example.com', status: 'pending' };
+      const client = mockClient({ put: vi.fn().mockResolvedValue(mockResult) });
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_bucket_domain_add',
+        { bucket_name: 'assets-itunified-de', domain: 'assets.example.com' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('assets.example.com');
+      expect(client.put).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets/assets-itunified-de/domains`,
+        { domain: 'assets.example.com' },
+      );
+    });
+
+    it('requires domain parameter', async () => {
+      const client = mockClient();
+
+      const result = await handleR2Tool(
+        'cloudflare_r2_bucket_domain_add',
+        { bucket_name: 'assets-itunified-de' },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Error executing cloudflare_r2_bucket_domain_add');
+    });
+  });
+
+  describe('cloudflare_r2_bucket_domain_remove', () => {
+    it('removes a custom domain from a bucket', async () => {
+      const client = mockClient({ delete: vi.fn().mockResolvedValue({}) });
+
+      await handleR2Tool(
+        'cloudflare_r2_bucket_domain_remove',
+        { bucket_name: 'assets-itunified-de', domain: 'assets.example.com' },
+        client,
+      );
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `/accounts/${ACCOUNT_ID}/r2/buckets/assets-itunified-de/domains/assets.example.com`,
       );
     });
   });


### PR DESCRIPTION
## Summary

- 3 new R2 domain tools: `domain_list`, `domain_add`, `domain_remove` (#45)
- Enables public access configuration via MCP — no dashboard needed
- 4 new unit tests (28 total R2 tests)
- R2 tools now total 10 (70 total across all domains)
- Updated skill docs, README, CHANGELOG

## Test plan

- [x] `npm run build` succeeds
- [x] 28 R2 tests pass
- [ ] Live test: `cloudflare_r2_bucket_domain_add` on existing bucket

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)