### PR TITLE
chore: add MCP Registry server.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "author": "itunified.io",
   "license": "AGPL-3.0-only",
+  "mcpName": "io.github.itunified-io/cloudflare",
   "repository": {
     "type": "git",
     "url": "https://github.com/itunified-io/mcp-cloudflare.git"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.itunified-io/cloudflare",
+  "title": "Cloudflare MCP Server",
+  "description": "Cloudflare MCP Server — 84 tools for DNS, Tunnels, WAF, Zero Trust, R2, KV & Workers",
+  "version": "2026.4.9",
+  "repository": {
+    "url": "https://github.com/itunified-io/mcp-cloudflare",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@itunified.io/mcp-cloudflare",
+      "version": "2026.4.9-1",
+      "runtimeHint": "npx",
+      "runtimeArguments": [],
+      "packageArguments": [],
+      "environmentVariables": [
+        {
+          "name": "CLOUDFLARE_API_TOKEN",
+          "description": "Cloudflare API Token with appropriate permissions",
+          "required": true
+        },
+        {
+          "name": "CLOUDFLARE_ACCOUNT_ID",
+          "description": "Cloudflare Account ID (required for account-level operations)",
+          "required": false
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `server.json` (schema 2025-12-11) for MCP Registry publishing
- Adds `mcpName` field to `package.json` for registry validation
- Namespace: `io.github.itunified-io/cloudflare`

🤖 Generated with [Claude Code](https://claude.com/claude-code)